### PR TITLE
Add JSON generator and fix link typos

### DIFF
--- a/mem-01-b.xml
+++ b/mem-01-b.xml
@@ -857,7 +857,7 @@ Watch Gowron say this: {YouTube video:url:http://www.youtube.com/v/kWP0lgIYMBA}<
       <column name="notes"></column>
       <column name="notes_de"></column>
       <column name="hidden_notes"></column>
-      <column name="components">{batlh:adv}, {Da-:v}, {qaw:v}, {-lu':}, {-taH:v}</column>
+      <column name="components">{batlh:adv}, {Da-:v}, {qaw:v}, {-lu':v}, {-taH:v}</column>
       <column name="examples"></column>
       <column name="examples_de"></column>
       <column name="search_tags">honour</column>
@@ -3155,7 +3155,7 @@ Watch Gowron say this: {YouTube video:url:http://www.youtube.com/v/NpFDKTzINH8}<
       <column name="definition_de">nervös, unruhig</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
-      <column name="see_also">{bergh:v}, {lIm:v}, {jot:v:1}, {jotHa':v}, {tI'qa':n}, {ghIj:v}, {Haj:v}</column>
+      <column name="see_also">{bergh:v}, {lIm:v}, {jot:v:1}, {jotHa':v}, {tI'qa' vIghro':n}, {ghIj:v}, {Haj:v}</column>
       <column name="notes">There is an idiom, {bIt; tI'qa' vIghro' rur}.[2]</column>
       <column name="notes_de"></column>
       <column name="hidden_notes">As the saying goes: once bitten, twice shy. On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:nolink}, but this is clearly a typo.</column>

--- a/mem-02-ch.xml
+++ b/mem-02-ch.xml
@@ -512,7 +512,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="notes">This is a regional word for {qettlhup:n}.</column>
       <column name="notes_de"></column>
       <column name="hidden_notes"></column>
-      <column name="components">{chanDoq:n}, {jeD:n}</column>
+      <column name="components">{chanDoq:n}, {jeD:v}</column>
       <column name="examples"></column>
       <column name="examples_de"></column>
       <column name="search_tags"></column>
@@ -534,7 +534,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="hidden_notes">Chang and Eng Bunker were a famous pair of Siamese twins.</column>
       <column name="components"></column>
       <column name="examples">
-▶ {tlhIngan chang'engvetlh:n}
+▶ {tlhIngan chang'engvetlh:sen}
 ▶ {nISwI' - cha' chang'engmey (telDaq lujomlu', nItebHa' lubaHlu'):sen:nolink} "Disruptor - 2 pairs (Wing Mounted, Fire Linked)[1]</column>
       <column name="examples_de"></column>
       <column name="search_tags"></column>
@@ -1179,7 +1179,7 @@ A {chaw':n:nolink} shows that you are officially or legally allowed to do or get
       <column name="notes">Klingons have twenty-three ribs ({joQ:n:1,body}). This expression means that something is not quite right.</column>
       <column name="notes_de"></column>
       <column name="hidden_notes"></column>
-      <column name="components">{cha':n:num}, {-maH:n:num}, {cha':n:num}, {joQ:n:1}, {-Du':n}</column>
+      <column name="components">{cha':n:num}, {maH:n:2,num}, {cha':n:num}, {joQ:n:1}, {-Du':n}</column>
       <column name="examples">
 ▶ {naDev cha'maH cha' joQDu' tu'lu':sen:nolink} (this means something strange is going on)
 ▶ {cha'maH cha' joQDu' ghaj qama':sen:nolink} "The prisoner has twenty-two ribs", i.e., he's a bit strange</column>
@@ -3228,7 +3228,7 @@ If the person you're speaking to is your superior, consider adding {-neS:v:suff}
       <column name="definition_de">Speer auf jdn. werfen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
-      <column name="see_also">{naQjej:n}, {ghuS:v:2}, {wob:v}, {tlhevjaQ:v}, {chuH:v:2}</column>
+      <column name="see_also">{naQjej:n}, {ghuS:v:2}, {wob:v}, {tlhevjaQ:n}, {chuH:v:2}</column>
       <column name="notes">This verb can only be used if the projectile is or resembles a spear. The object of this verb is the intended target. The suffix {-chu':v:suff} is used with this verb to indicate that the target is actually hit. [1, p.64]</column>
       <column name="notes_de"></column>
       <column name="hidden_notes">"Chuck".</column>

--- a/mem-03-D.xml
+++ b/mem-03-D.xml
@@ -1755,7 +1755,7 @@ Watch Gowron say this: {YouTube video:url:http://www.youtube.com/v/7qXuTn9HpP4}<
       <column name="notes"></column>
       <column name="notes_de"></column>
       <column name="hidden_notes"></column>
-      <column name="components">{Dev:v}, {meH:v}, {paq:n:1h}</column>
+      <column name="components">{Dev:v}, {-meH:v}, {paq:n:1h}</column>
       <column name="examples"></column>
       <column name="examples_de"></column>
       <column name="search_tags"></column>
@@ -4433,7 +4433,7 @@ Known classes of Klingon ships include {neghvar:n}, {vorcha':n}, {qItI'nga':n}, 
       <column name="notes"></column>
       <column name="notes_de"></column>
       <column name="hidden_notes"></column>
-      <column name="components">{Duj:n:2}, {-lIj:n}, {yI:v}, {voq:v}</column>
+      <column name="components">{Duj:n:2}, {-lIj:n}, {yI-:v}, {voq:v}</column>
       <column name="examples"></column>
       <column name="examples_de"></column>
       <column name="search_tags"></column>

--- a/mem-04-gh.xml
+++ b/mem-04-gh.xml
@@ -2608,7 +2608,7 @@ Watch Gowron say this: {YouTube video:url:http://www.youtube.com/v/7_rXiSTQmAE}<
       <column name="definition_de">Gruppe, Partei</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
-      <column name="see_also">{ghom:v}, {tlhach:n}, {Hoq:n}, {boq:n:n1}, {DIvI':n}, {qev:n}, {DaH:n}, {ghom'a':n}, {tlhoQ:n}</column>
+      <column name="see_also">{ghom:v}, {tlhach:n}, {Hoq:n}, {boq:n:1}, {DIvI':n}, {qev:n}, {DaH:n}, {ghom'a':n}, {tlhoQ:n}</column>
       <column name="notes"></column>
       <column name="notes_de"></column>
       <column name="hidden_notes"></column>
@@ -3309,7 +3309,7 @@ This word is alien in origin. The reason Klingons use an alien word for this is 
       <column name="definition_de">einen Ton erzeugen, äußern</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
-      <column name="see_also">{jatlh:v}, {'Imyagh:excl}, {wel:excl}</column>
+      <column name="see_also">{jatlh:v}, {'Imyagh:excl}, {welwelwel:excl}</column>
       <column name="notes">This refers to sound emitted by an animal, but not speech.</column>
       <column name="notes_de">Dies wird nur bei Tiergeräuschen verwendet, nicht bei Sprache.</column>
       <column name="hidden_notes"></column>

--- a/mem-05-H.xml
+++ b/mem-05-H.xml
@@ -980,7 +980,7 @@ To use such a device, one may {qIp:v}, {'uy:v}, or {ngaH:v} it, depending on the
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Ha'quj nge':sen:idiom}, {mong Ha'quj:n}</column>
-      <column name="notes">In ancient times, this supported a sword. Now it is symbolic of one's {tuq:v}.</column>
+      <column name="notes">In ancient times, this supported a sword. Now it is symbolic of one's {tuq:n}.</column>
       <column name="notes_de"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
@@ -3079,7 +3079,7 @@ The identifier is usually a country, region, or political unit of some kind. For
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
-      <column name="notes">Due to the homophony with {Hom:2:n}, to point one's second toe at someone (typically an opponent or an enemy), while the other toes point downwards, is considered an insulting gesture. It signifies that one considers the other person to be weak.</column>
+      <column name="notes">Due to the homophony with {Hom:n:2}, to point one's second toe at someone (typically an opponent or an enemy), while the other toes point downwards, is considered an insulting gesture. It signifies that one considers the other person to be weak.</column>
       <column name="notes_de"></column>
       <column name="hidden_notes">This little piggy stayed home.</column>
       <column name="components"></column>
@@ -3904,7 +3904,7 @@ This verb is also used for regular polygons and polyhedra.[2]</column>
       <column name="notes"></column>
       <column name="notes_de"></column>
       <column name="hidden_notes"></column>
-      <column name="components">{Ho':n:1}, {teywI':v}</column>
+      <column name="components">{Ho':n:1}, {teywI':n}</column>
       <column name="examples"></column>
       <column name="examples_de"></column>
       <column name="search_tags"></column>

--- a/mem-06-j.xml
+++ b/mem-06-j.xml
@@ -2136,7 +2136,7 @@ To express a wish for something to happen, see {-jaj:v}.</column>
       <column name="hidden_notes">A reference to the genie (or jinn) of Arabian mythology.</column>
       <column name="components"></column>
       <column name="examples">
-▶ {tlhIngan jIH 'e' vIjIn.@@tlhIngan:n, jIH:n:1, 'e':n, vI-:n, jIn:v} "I wish I were a Klingon."</column>
+▶ {tlhIngan jIH 'e' vIjIn.@@tlhIngan:n, jIH:n:1, 'e':n, vI-:v, jIn:v} "I wish I were a Klingon."</column>
       <column name="examples_de"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
@@ -2330,7 +2330,7 @@ To express a wish for something to happen, see {-jaj:v}.</column>
       <column name="definition_de">Mumie</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
-      <column name="see_also">{pe'laQ:n:2}, {'Impey':n}, {nev'aQ:n}, {nebeylI':n}, {jItuj'ep ngutlh:n}</column>
+      <column name="see_also">{pel'aQ:n:2}, {'Impey':n}, {nev'aQ:n}, {nebeylI':n}, {jItuj'ep ngutlh:n}</column>
       <column name="notes"></column>
       <column name="notes_de"></column>
       <column name="hidden_notes">This is a reference to Imhotep ({jItuj:sen@@jI-:v, tuj:v} means "I'm hot").</column>

--- a/mem-07-l.xml
+++ b/mem-07-l.xml
@@ -3409,7 +3409,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="definition_de">raten</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
-      <column name="see_also">{ghut:v}, {noH:v}, {Sov:t}, {Har:t}</column>
+      <column name="see_also">{ghut:v}, {noH:v}, {Sov:v}, {Har:v}</column>
       <column name="notes"></column>
       <column name="notes_de"></column>
       <column name="hidden_notes"></column>

--- a/mem-09-n.xml
+++ b/mem-09-n.xml
@@ -3774,7 +3774,7 @@ See {SIq:v} for an explanation of the usage of these finger verbs.</column>
       <column name="see_also">{nung:v}, {cho':v}</column>
       <column name="notes"></column>
       <column name="notes_de"></column>
-      <column name="hidden_notes">The joke is that the definition of this word is one which is suspect, since {nub:v} means "be suspect". Also, this word is before {nung:n} in {TKD:src}.</column>
+      <column name="hidden_notes">The joke is that the definition of this word is one which is suspect, since {nub:v} means "be suspect". Also, this word is before {nung:v} in {TKD:src}.</column>
       <column name="components"></column>
       <column name="examples">
 ▶ {qeylIS bov nubwI':n}</column>

--- a/mem-11-p.xml
+++ b/mem-11-p.xml
@@ -234,7 +234,7 @@ The imperative verb prefix when {pagh:n:1h,nolink} is the object is {yI-:v:pref}
       <column name="definition_de">Umhang, Robe</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
-      <column name="see_also">{mop:n:1}, {paH bID:n}</column>
+      <column name="see_also">{mop:n}, {paH bID:n}</column>
       <column name="notes"></column>
       <column name="notes_de"></column>
       <column name="hidden_notes">This is defined in {TKD:src} as "gown". In {TNK:src}, it is used for "dress", while {paH bID:n} is used for "skirt".</column>
@@ -764,7 +764,7 @@ Note that the Klingon term for a star system is {Hovtay':n}.</column>
       <column name="definition_de"></column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
-      <column name="see_also">{patlh:n}, {patlhmoH:v}, {tetlh:v}</column>
+      <column name="see_also">{patlh:n}, {patlhmoH:v}, {tetlh:n}</column>
       <column name="notes">To sort a list of English words alphabetically, use a construction such as {wa'DIch a, HochDIch z:sen:nolink} (or {wa'DIch z, HochDIch a:sen:nolink} for reverse order). For Klingon words, use {wa'DIch bay, HochDIch qaghwI':sen:nolink} or {wa'DIch qaghwI', HochDIch bay:sen:nolink}. To reverse a list, use {DopmoH:v@@Dop:v, -moH:v}.[2]</column>
       <column name="notes_de"></column>
       <column name="hidden_notes"></column>
@@ -3130,7 +3130,7 @@ In the promotional posters and videos for {DSC:src}, as well as in the backgroun
       <column name="notes"></column>
       <column name="notes_de"></column>
       <column name="hidden_notes"></column>
-      <column name="components">{pol:v}, {-Ha:v}</column>
+      <column name="components">{pol:v}, {-Ha':v}</column>
       <column name="examples"></column>
       <column name="examples_de"></column>
       <column name="search_tags"></column>
@@ -4027,7 +4027,7 @@ In the promotional posters and videos for {DSC:src}, as well as in the backgroun
       <column name="hidden_notes">This is missing from the E-K side of {TKD:src}.</column>
       <column name="components">{puj:v}, {-moH:v}</column>
       <column name="examples">
-▶ {jaghpu'ra' bopujmoHtaHvIS, ghur tuqmeyraj quv.:sen@@jagh:n, -pu':n, -ra':n, bo-:v, pujmoH:v, -taH:v, -vIS:v, ghur:v, tuq:n, -mey:n, -raj:n quv:n} "Honor will rise in your houses as you bring your enemies to their knees."[3]</column>
+▶ {jaghpu'ra' bopujmoHtaHvIS, ghur tuqmeyraj quv.:sen@@jagh:n, -pu':n, -ra':n, bo-:v, pujmoH:v, -taH:v, -vIS:v, ghur:v, tuq:n, -mey:n, -raj:n, quv:n} "Honor will rise in your houses as you bring your enemies to their knees."[3]</column>
       <column name="examples_de"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
@@ -4561,7 +4561,7 @@ In the promotional posters and videos for {DSC:src}, as well as in the backgroun
       <column name="definition_de">fliegen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
-      <column name="see_also">{qaj:v}, {'or:v}, {muD Duj:v}, {'al:v}</column>
+      <column name="see_also">{qaj:v}, {'or:v}, {muD Duj:n}, {'al:v}</column>
       <column name="notes"></column>
       <column name="notes_de"></column>
       <column name="hidden_notes"></column>

--- a/mem-12-q.xml
+++ b/mem-12-q.xml
@@ -5149,7 +5149,7 @@ Note that {ghaj:v} and {Hutlh:v} can be used with this noun to indicate that som
       <column name="definition_de">übergeben</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
-      <column name="see_also">{'em:v}, {HuH:v}</column>
+      <column name="see_also">{'em:v}, {HuH:n}</column>
       <column name="notes"></column>
       <column name="notes_de"></column>
       <column name="hidden_notes">Note that the reverse, {pI'yuq:sen:nolink}, is phonetically "puke".</column>

--- a/mem-14-r.xml
+++ b/mem-14-r.xml
@@ -3183,7 +3183,7 @@ In the context of playing dice, this word refers to the action of the dice as th
 ▶ {boch; ghIch rur}
 ▶ {Dejpu'bogh Hov rur qablIj!:sen}
 ▶ {Dogh; tIghla' rur@@Dogh:v, tIghla':n, rur:v}
-▶ {lo'laHbe'; chetvI' chIm rur@@lo'laHbe':v, chetvI':v:1, chIm:v, rur:v}
+▶ {lo'laHbe'; chetvI' chIm rur@@lo'laHbe':v, chetvI':n:1, chIm:v, rur:v}
 ▶ {ghung; qagh rur@@ghung:v, qagh:n, rur:v}
 ▶ {Hem; tlhIngan rur}
 ▶ {Hoj; tera'ngan rur}

--- a/mem-15-S.xml
+++ b/mem-15-S.xml
@@ -3518,7 +3518,7 @@ This exclamation indicates that the speaker is about to give a command, or is re
       <column name="synonyms"></column>
       <column name="antonyms">{Hop:v}</column>
       <column name="see_also">{chol:v}, {chuq:n}</column>
-      <column name="notes">The use of this word involves the concept of deixis. It usually implies the subject is near the speaker, unless the context is set up to indicate the action is taking place somewhere else (for example, using {-Daq:v}). The suffix {-chuq:v} is not used with this verb.[2]
+      <column name="notes">The use of this word involves the concept of deixis. It usually implies the subject is near the speaker, unless the context is set up to indicate the action is taking place somewhere else (for example, using {-Daq:n}). The suffix {-chuq:v} is not used with this verb.[2]
 
 The expression {jISum:sen:nolink} has an idiomatic philosophical meaning, "I'm in touch with my inner self" (in a Klingon way).[2]</column>
       <column name="notes_de"></column>

--- a/mem-16-t.xml
+++ b/mem-16-t.xml
@@ -934,7 +934,7 @@ This dialect is sort of half-way between the standard dialect and the {Qotmagh S
       <column name="definition_de">Targ</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
-      <column name="see_also">{namwech:n}, {wel:excl}</column>
+      <column name="see_also">{namwech:n}, {welwelwel:excl}</column>
       <column name="notes">This is a kind of animal somewhat resembling a dog. It is popular as a pet, but its heart is also considered a delicacy.[2]</column>
       <column name="notes_de"></column>
       <column name="hidden_notes"></column>
@@ -1700,7 +1700,7 @@ This dialect is sort of half-way between the standard dialect and the {Qotmagh S
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hovtay':n}</column>
-      <column name="notes">This star system is located near the Federation-Klingon border, and contains the two planets {Doy'yuS:n} and {'elas:n}.</column>
+      <column name="notes">This star system is located near the Federation-Klingon border, and contains the two planets {Doy'yuS:n} and {'elaS:n}.</column>
       <column name="notes_de"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>

--- a/mem-18-v.xml
+++ b/mem-18-v.xml
@@ -672,7 +672,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="definition_de">Halle, Versammlungshalle</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
-      <column name="see_also">{vaS:'a'}</column>
+      <column name="see_also">{vaS'a':n}</column>
       <column name="notes"></column>
       <column name="notes_de"></column>
       <column name="hidden_notes">"Vast".</column>
@@ -973,7 +973,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="notes_de"></column>
       <column name="hidden_notes">While {nungbogh:v:nolink} precedes a noun, {veb:v:nolink} comes after one.</column>
       <column name="components"></column>
-      <column name="examples">{puH poH veb:n}</column>
+      <column name="examples">{puq poH veb:n}</column>
       <column name="examples_de"></column>
       <column name="search_tags">after, next</column>
       <column name="search_tags_de"></column>

--- a/mem-20-y.xml
+++ b/mem-20-y.xml
@@ -942,7 +942,7 @@ Do not confuse this with a society in the cultural sense, for which see {nugh:n}
       <column name="synonyms"></column>
       <column name="antonyms">{yep:v}</column>
       <column name="see_also"></column>
-      <column name="notes">In the {ruq'e'vet:n} dialect, {ghIH:v:2} means {yepHa':2}.</column>
+      <column name="notes">In the {ruq'e'vet:n} dialect, {ghIH:v:2} means {yepHa':v:nolink}.</column>
       <column name="notes_de"></column>
       <column name="hidden_notes"></column>
       <column name="components">{yep:v}, {-Ha':v}</column>

--- a/mem-24-o.xml
+++ b/mem-24-o.xml
@@ -894,7 +894,7 @@ This word is also written {'orghenya'ngan:n:nolink}.</column>
       <column name="notes"></column>
       <column name="notes_de"></column>
       <column name="hidden_notes"></column>
-      <column name="components">{'oy':v}, {-be':v}, {-lu':}, {-chugh:v}, {Qap:v:1}, {-be':v}, {-lu':v}</column>
+      <column name="components">{'oy':v}, {-be':v}, {-lu':v}, {-chugh:v}, {Qap:v:1}, {-be':v}, {-lu':v}</column>
       <column name="examples"></column>
       <column name="examples_de"></column>
       <column name="search_tags"></column>

--- a/mem-25-u.xml
+++ b/mem-25-u.xml
@@ -383,7 +383,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="definition_de">Topf (allg. Begriff für Kochtopf, auch wenn Hitze nicht involviert ist)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
-      <column name="see_also">{DuDwI':}, {'un naQ:n}, {bo'Dagh:n}</column>
+      <column name="see_also">{DuDwI':n}, {'un naQ:n}, {bo'Dagh:n}</column>
       <column name="notes"></column>
       <column name="notes_de"></column>
       <column name="hidden_notes"></column>

--- a/mem-27-extra.xml
+++ b/mem-27-extra.xml
@@ -1687,7 +1687,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="notes">This refers to a concept in computer programming, namely, a segment of code which is repeatedly executed until some condition is met.</column>
       <column name="notes_de"></column>
       <column name="hidden_notes"></column>
-      <column name="components">{vIH:v}, {-taH:v}, {-bogh:n}, {gho:n}</column>
+      <column name="components">{vIH:v}, {-taH:v}, {-bogh:v}, {gho:n}</column>
       <column name="examples"></column>
       <column name="examples_de"></column>
       <column name="search_tags"></column>

--- a/xml2json.py
+++ b/xml2json.py
@@ -60,6 +60,7 @@ import xml.etree.ElementTree as ET
 import json
 import sys
 import fileinput
+import os
 
 # A single entry parsed from the XML tree
 class EntryNode:
@@ -175,9 +176,10 @@ memparts = ['header', 'b', 'ch', 'D', 'gh', 'H', 'j', 'l', 'm', 'n', 'ng', 'p',
             'u', 'suffixes', 'extra', 'footer']
 filenames = []
 concat=''
+sdir = os.path.dirname(os.path.realpath(sys.argv[0]))
 
 for i, part in enumerate(memparts):
-    filenames.append('mem-{0:02d}-{1}.xml'.format(i, part))
+    filenames.append(os.path.join(sdir,'mem-{0:02d}-{1}.xml'.format(i, part)))
 
 # Concatenate the individual files into a single database string
 mem = fileinput.FileInput(files=filenames)
@@ -186,7 +188,7 @@ for line in mem:
 mem.close()
 
 # Read the database version from the version file
-ver = fileinput.FileInput(files=('VERSION'))
+ver = fileinput.FileInput(files=(os.path.join(sdir,'VERSION')))
 version = ver[0].strip()
 ver.close()
 

--- a/xml2json.py
+++ b/xml2json.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python
+
+# xml2json.py
+#
+# Read the database XML files and output a JSON representation of the database
+# to stdout, and report unresolvable links to stderr.
+#
+# The JSON structure is roughly:
+#
+# {
+#   "format_version" : "1"
+#   "version" : "<database_version>",
+#   "qawHaq" : {
+#     "<search_name>" : {
+#         "_id" : "<id>",
+#         "entry_name" : "<entry name>",
+#         "part_of_speech" : "<part_of_speech>",
+#         "definition" : {
+#           "de" : "<definition_de>"
+#           "en" : "<definition>"
+#         },
+#         "synonyms" : "<synonyms>",
+#         "antonyms" : "<antonyms>",
+#         "see_also" : "<see_also>",
+#         "notes" : {
+#           "de" : "<notes_de>",
+#           "en" : "<notes>",
+#         },
+#         "hidden_notes" : "<hidden_notes>",
+#         "components" : "<components>",
+#         "examples" : {
+#           "de" : "<examples_de>",
+#           "en" : "<examples>",
+#         },
+#         "search_tags" : {
+#           "de" : "<search_tags_de>",
+#           "en" : "<search_tags>",
+#         },
+#         "source" : "<source>"
+#     },
+#     ...
+#   }
+# }
+#
+# format_version must be incremented if the format changes in a backwards
+# incompatible way (adding new fields ought to be backwards compatible).
+#
+# version is the version of the database
+#
+# search_name is constructed as: entry_name:base_part_of_speech(:homophone_num),
+# where entry_name is the entry name, base_part_of_speech is the first field of
+# the part of speech (e.g. "n" rather than "n:name"), and homophone_num is the
+# homophone number parsed from the part_of_speech field, if present. Entries
+# with no homophones do not specify a homophone field.
+#
+# The remaining values are taken directly from the XML database. Empty values
+# are omitted from the JSON representation.
+
+import xml.etree.ElementTree as ET
+import json
+import sys
+import fileinput
+
+# A single entry parsed from the XML tree
+class EntryNode:
+    # Constructor from XML node
+    def __init__(self, node):
+        self.data = {}
+        # Iterate over columns in the entry and store their values
+        for child in node:
+            if child.tag == 'column':
+                name = child.attrib['name']
+                localized = ''
+                text = ''.join(child.itertext())
+                if text:
+                    # Store localized fields hierarchically
+                    if name in [
+                        'definition', 'definition_de',
+                        'notes', 'notes_de',
+                        'search_tags', 'search_tags_de',
+                        'examples', 'examples_de',
+                    ]:
+                        localized = name.rstrip('_de')
+                        if name.endswith('_de'):
+                            locale = 'de'
+                        else:
+                            locale = 'en'
+                        if not localized in self.data:
+                            self.data[localized] = {}
+                        self.data[localized][locale] = text
+                    # Non localized fields are stored at the entry's top level
+                    else:
+                        self.data[name] = text
+
+    # Normalize the search name from the stored entry name and part of speech
+    def searchName(self):
+        return normalize(self.data['entry_name'], self.data['part_of_speech'])
+
+# Convert an entry name and part of speech, which may include a homophone
+# number and non-homophone tags, into a normalized search name
+def normalize(name, pos):
+    # Split part of speech into separate fields
+    posSplit = pos.split(':')
+    pos = posSplit[0]
+    # If there is a second field, it contains comma-separated tags
+    if len(posSplit) > 1:
+        flags = posSplit[1]
+    else:
+        flags = ''
+    homophone = ''
+    # Look for a homophone number in the flags. Ignore an 'h' which is used
+    # to indicate a hidden homophone number.
+    for flag in flags.split(','):
+        flag = flag.rstrip('h')
+        if flag.isdigit():
+            homophone = ':' + flag
+            break
+    return name + ':' + pos + homophone
+
+# Traverse the database tree and try to identify links that cannot be resolved
+# unambiguously to an entry. Report any unresolvable links to stderr.
+def validatelinks(root, node):
+    # If this node is a dict, recurse into its children
+    if isinstance(node, dict):
+        for subnode in node:
+            validatelinks(root, node[subnode])
+    else:
+        # Find all text in {curly braces}
+        remaining = node
+        while remaining.find('{') != -1:
+            remaining = remaining[remaining.find('{')+1:]
+            tag = remaining[0:remaining.find('}')]
+
+            # For {sentences with components@@sentences, with, components},
+            # check the individual components.
+            if tag.find('@@') != -1:
+                for term in tag.split('@@')[1].split(','):
+                    validatelinks(root, '{' + term.strip(' ') + '}')
+                continue
+
+            tagsplit = tag.split(':')
+
+            if len(tagsplit) > 1:
+                # The second field identifies the text type: don't bother
+                # validating url links, src attributions, or sentences.
+                if tagsplit[1] == 'url' or \
+                    tagsplit[1] == 'src' or \
+                    tagsplit[1] == 'sen':
+                    continue
+                # Check the flags in the third field and ignore text tagged
+                # with the "nolink" flag.
+                if len(tagsplit) > 2 and 'nolink' in tagsplit[2].split(','):
+                    continue
+
+                # Normalize the search name and check if an entry exists
+                normalized = normalize(tagsplit[0], ':'.join(tagsplit[1:]))
+                if not normalized in root:
+                    hom = ''
+
+                    # Check if the failure to resolve was due to an ambiguous
+                    # homophone
+                    if normalized + ':1' in root:
+                        hom = ' (homophone exists)'
+                    # A homophone number of 0 explicitly indicates that the
+                    # link is supposed to lead to all homophones
+                    elif normalized[-2:] == ':0':
+                        if normalized[:-2] + ':1' in root:
+                            continue
+
+                    sys.stderr.write('no entry for {' + tag + '}' + hom + '.\n')
+
+# Section names of the individual XML fragments that make up the database
+memparts = ['header', 'b', 'ch', 'D', 'gh', 'H', 'j', 'l', 'm', 'n', 'ng', 'p',
+            'q', 'Q', 'r', 'S' ,'t', 'tlh', 'v', 'w', 'y', 'a', 'e', 'I', 'o',
+            'u', 'suffixes', 'extra', 'footer']
+filenames = []
+concat=''
+
+for i, part in enumerate(memparts):
+    filenames.append('mem-{0:02d}-{1}.xml'.format(i, part))
+
+# Concatenate the individual files into a single database string
+mem = fileinput.FileInput(files=filenames)
+for line in mem:
+    concat += line
+mem.close()
+
+# Read the database version from the version file
+ver = fileinput.FileInput(files=('VERSION'))
+version = ver[0].strip()
+ver.close()
+
+# Parse the database XML tree and store the parsed entries in a dict
+xmltree = ET.fromstring(concat)
+qawHaq = {}
+for child in xmltree[0]:
+    node = EntryNode(child)
+    qawHaq[node.searchName()] = node.data
+
+# Now that the database has been parsed, search for unfollowable links
+validatelinks(qawHaq, qawHaq)
+
+# Dump the database as JSON
+print(json.dumps({'version' : version, 'qawHaq' : qawHaq}))


### PR DESCRIPTION
The nonexistent entries referred to in item (2) in the description of c1bf9332 are:

peH:n
peH:v
rISwI':n
rItwI':n

The two peH entries are hypotheticals, and the two derived nouns can be parsed as verb + wI'. It wasn’t clear to me if the intention was to add entries or set nolink, so I left those alone. For the derived nouns it’s possible that the lack of an entry is intentional, though other similarly derived nouns have entries.