### PR TITLE
Decompose Unicode characters

### DIFF
--- a/xml2json.py
+++ b/xml2json.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # xml2json.py
 #
@@ -65,6 +65,7 @@ import sys
 import fileinput
 import os
 import re
+import unicodedata
 
 # A single entry parsed from the XML tree
 class EntryNode:
@@ -76,7 +77,8 @@ class EntryNode:
             if child.tag == 'column':
                 name = child.attrib['name']
                 localized = name.rstrip('_de')
-                text = ''.join(child.itertext())
+                # Normalize Unicode characters into decomposed form
+                text = unicodedata.normalize('NFKD', ''.join(child.itertext()))
                 if text:
                     # Store localized fields hierarchically
                     if localized in [


### PR DESCRIPTION
Normalize Unicode to the NFKD form (NFD is probably fine, but NFKD is
chosen out of an abundance of caution) in the JSON representation of
the database so that the app doesn't have to do it at load time.

As part of this, change the shebang to explicitly request python 3,
since python 2 Unicode support is hard. Prior to this change, this
script worked in both Python 2 and Python 3.

This is work towards dadap/flingon-assister#19