### PR TITLE
corrections on German entries

### DIFF
--- a/mem-04-gh.xml
+++ b/mem-04-gh.xml
@@ -268,7 +268,7 @@ The imperative verb prefix when {ghaH:n:nolink} is the object is {yI-:v:pref}.</
       <column name="entry_name">ghanHa'</column>
       <column name="part_of_speech">v:is</column>
       <column name="definition">peaceful, calm</column>
-      <column name="definition_de">fridlich, entspannt, ruhig</column>
+      <column name="definition_de">friedlich, entspannt, ruhig</column>
       <column name="synonyms"></column>
       <column name="antonyms">{ghan:v}</column>
       <column name="see_also"></column>
@@ -1072,7 +1072,7 @@ The object of this verb is the question asked.</column>
       <column name="entry_name">ghe'</column>
       <column name="part_of_speech">v:is</column>
       <column name="definition">be transformed, transmuted, metamorphosed, totally altered</column>
-      <column name="definition_de">umgewandelt werden, transmutiert werden, metamorphosiert werden, völlig verändert sein</column>
+      <column name="definition_de">umgewandelt, transmutiert, metamorphosiert, völlig verändert</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{choH:v}, {choH:n}</column>
@@ -1093,12 +1093,13 @@ The object of this verb is the question asked.</column>
       <column name="entry_name">ghe'chem</column>
       <column name="part_of_speech">n</column>
       <column name="definition">terraforming field</column>
-      <column name="definition_de">Terraformierungfeld</column>
+      <column name="definition_de">Terraforming-Feld</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
       <column name="notes">This is a short way to refer to an energy field of some sort that causes terraforming to happen. A longer way to refer to this concept would be {ghe'moHbogh HoSchem:n@@ghe':v, -moH:v, -bogh:v, HoSchem:n}.</column>
       <column name="notes_de"></column>
+      <!-- In German version of Netflix, it is translated as Terraforming-Bereich, which refers to an area. So maybe Stamets was not talking about a technical field, but just to a field of land -->
       <column name="hidden_notes"></column>
       <column name="components">{ghe':v}, {chem:n:hyp}</column>
       <column name="examples"></column>
@@ -1523,7 +1524,7 @@ There is also a regional word {ley':n} which means "nose".</column>
       <column name="entry_name">ghIm</column>
       <column name="part_of_speech">v:t_c</column>
       <column name="definition">exile</column>
-      <column name="definition_de">verbannen, exilieren, ins Exil schicken</column>
+      <column name="definition_de">ausstoßen, auswerfen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghImwI':n}, {vuj:v}, {ruq:v}, {puch:n}</column>
@@ -1644,7 +1645,7 @@ There is also a regional word {ley':n} which means "nose".</column>
       <column name="entry_name">ghIpDIj</column>
       <column name="part_of_speech">v:t</column>
       <column name="definition">court-martial</column>
-      <column name="definition_de">Kriegsgericht</column>
+      <column name="definition_de">vor Kriegsgericht gestellt werden</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bo'DIj:n}</column>
@@ -2177,7 +2178,7 @@ There are 243 {lawmey:n:nolink} in a {gho:n:nolink}, or 360 {lawrI'mey:n:nolink}
       <column name="entry_name">ghob</column>
       <column name="part_of_speech">v:t_c</column>
       <column name="definition">fight, battle, do battle, wage war</column>
-      <column name="definition_de">Krieg führen</column>
+      <column name="definition_de">kämpfen, Krieg führen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{may':n}, {noH:n}</column>
@@ -2241,7 +2242,7 @@ In ascending order of ferocity, the verbs used to describe military confrontatio
       <column name="entry_name">ghobe'</column>
       <column name="part_of_speech">excl</column>
       <column name="definition">no (answer to a question)</column>
-      <column name="definition_de">nein</column>
+      <column name="definition_de">nein (Antwort auf eine Frage)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{HIja':excl}, {HISlaH:excl}</column>
       <column name="see_also">{-'a':v:suff}, {Qo':excl}</column>


### PR DESCRIPTION
corrected some of the German entries; 
side note: all to-be-verbs, i.e. adjectives, have been translated as adjective in German. So, just "klein" instead of "klein sein".