### PR TITLE
Move Swedish definitions that were accidentally in the Farsi field

### DIFF
--- a/mem-02-ch.xml
+++ b/mem-02-ch.xml
@@ -6306,8 +6306,8 @@ If the person you're speaking to is your superior, consider adding {-neS:v:suff}
       <column name="part_of_speech">n:fic</column>
       <column name="definition">type of musical instrument</column>
       <column name="definition_de">eine Art Musikinstrument</column>
-      <column name="definition_fa">ett slags musikinstrument</column>
-      <column name="definition_sv"></column>
+      <column name="definition_fa"></column>
+      <column name="definition_sv">ett slags musikinstrument</column>
       <column name="definition_ru"></column>
       <column name="definition_zh_HK"></column>
       <column name="synonyms"></column>

--- a/mem-03-D.xml
+++ b/mem-03-D.xml
@@ -6179,8 +6179,8 @@ Coincidentally or not, this words sounds similar to {DI vI':n:nolink} "it accumu
       <!-- Possibly means "face" in the geometric sense. -->
       <column name="definition">side</column>
       <column name="definition_de">Seite</column>
-      <column name="definition_fa">sida</column>
-      <column name="definition_sv"></column>
+      <column name="definition_fa"></column>
+      <column name="definition_sv">sida</column>
       <column name="definition_ru"></column>
       <column name="definition_zh_HK"></column>
       <column name="synonyms"></column>

--- a/mem-04-gh.xml
+++ b/mem-04-gh.xml
@@ -6356,8 +6356,8 @@ This word is alien in origin. The reason Klingons use an alien word for this is 
       <column name="definition">increase</column>
       <column name="definition_de">zunehmen</column>
       <!-- {ghurmoH:v} would be "erhöhen, steigern". -->
-      <column name="definition_fa">öka</column>
-      <column name="definition_sv"></column>
+      <column name="definition_fa"></column>
+      <column name="definition_sv">öka</column>
       <column name="definition_ru"></column>
       <column name="definition_zh_HK"></column>
       <column name="synonyms"></column>

--- a/mem-07-l.xml
+++ b/mem-07-l.xml
@@ -2866,8 +2866,8 @@ This word can be used figuratively. There is an idiom, {let mInDu'Daj; Separmey 
       <!-- maybe combine these definitions? -->
       <column name="definition">he/she/it-you (plural), they-you (plural)</column>
       <column name="definition_de">er/sie/es/sie(pl.)-euch</column>
-      <column name="definition_fa">han/hon/det/de-er</column>
-      <column name="definition_sv"></column>
+      <column name="definition_fa"></column>
+      <column name="definition_sv">han/hon/det/de-er</column>
       <column name="definition_ru"></column>
       <column name="definition_zh_HK"></column>
       <column name="synonyms"></column>
@@ -5004,8 +5004,8 @@ The text of {SkyBox 99:src} reads:
       <!-- It is unclear if this can take a subject, such as an angle. -->
       <column name="definition">be in an attitude (aircraft)</column>
       <column name="definition_de">in einer Fluglage befinden (Flugzeug)</column>
-      <column name="definition_fa">vara i en position, vara i ett läge, vara i en pose, vara i en</column>
-      <column name="definition_sv"></column>
+      <column name="definition_fa"></column>
+      <column name="definition_sv">vara i en position, vara i ett läge, vara i en pose, vara i en</column>
       <column name="definition_ru"></column>
       <column name="definition_zh_HK"></column>
       <column name="synonyms"></column>

--- a/mem-08-m.xml
+++ b/mem-08-m.xml
@@ -2515,8 +2515,8 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="definition">battle cruiser</column>
       <!-- Or "Schlachtkreuzer". -->
       <column name="definition_de">Kampfkreuzer</column>
-      <column name="definition_fa">stridskryssare</column>
-      <column name="definition_sv"></column>
+      <column name="definition_fa"></column>
+      <column name="definition_sv">stridskryssare</column>
       <column name="definition_ru"></column>
       <column name="definition_zh_HK"></column>
       <column name="synonyms"></column>

--- a/mem-09-n.xml
+++ b/mem-09-n.xml
@@ -7266,8 +7266,8 @@ See {SIq:v} for an explanation of the usage of these finger verbs.</column>
       <!-- plural? -->
       <column name="definition">small arms</column>
       <column name="definition_de">Handwaffen</column>
-      <column name="definition_fa">handvapen</column>
-      <column name="definition_sv"></column>
+      <column name="definition_fa"></column>
+      <column name="definition_sv">handvapen</column>
       <column name="definition_ru"></column>
       <column name="definition_zh_HK"></column>
       <column name="synonyms"></column>


### PR DESCRIPTION
There were a few recently imported Swedish definitions that accidentally
ended up in the Farsi definition field. Move them to the correct field.