### PR TITLE
Fix Russian definition of {'oH}

### DIFF
--- a/mem-24-o.xml
+++ b/mem-24-o.xml
@@ -394,7 +394,7 @@
       <column name="definition_de">es</column>
       <column name="definition_fa">آن</column>
       <column name="definition_sv">den, det</column>
-      <column name="definition_ru">он, она, оно, его, ее (вещи, которые не способны к языку)</column>
+      <column name="definition_ru">он, она, оно, его, её (для вещей, не способных использовать речь)</column>
       <column name="definition_zh_HK">它、牠</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>


### PR DESCRIPTION
Match @Sigrlin's convention of "способных использовать речь" for
"capable of speech". Also add diaresis on её, since it seems more
appropriate within the context of a dictionary.