### PR TITLE
verb "poH" cannot mean "Zeit" in german - that's a noun

### DIFF
--- a/mem-11-p.xml
+++ b/mem-11-p.xml
@@ -5577,7 +5577,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</col
       <column name="entry_name">poH</column>
       <column name="part_of_speech">v:t_c</column>
       <column name="definition">time</column>
-      <column name="definition_de">Zeit</column>
+      <column name="definition_de">Zeit messen</column>
       <column name="definition_fa">زمان [AUTOTRANSLATED]</column>
       <column name="definition_sv">klocka, ta tid på, bestämma tid för</column>
       <column name="definition_ru"></column>


### PR DESCRIPTION
I've changed it to "Zeit messen", although I think there must be a better way to say it. The casual word would be "stoppen", but that is too similar to "to stop something" to be useful, IMO.