### PR TITLE
'e' in german is "das" (single s)

### DIFF
--- a/mem-22-e.xml
+++ b/mem-22-e.xml
@@ -2199,7 +2199,7 @@ This word should not be confused with {'eQway:n}.</column>
       <column name="entry_name">'e'</column>
       <column name="part_of_speech">n:pro</column>
       <column name="definition">that (previous topic)</column>
-      <column name="definition_de">dass, welches (voriges Thema)</column>
+      <column name="definition_de">das, welches (voriges Thema)</column>
       <column name="definition_fa">که (موضوع قبلی) [AUTOTRANSLATED]</column>
       <column name="definition_sv">det (föregående ämne)</column>
       <column name="definition_ru">что (предыдущая тема)</column>

--- a/mem-22-e.xml
+++ b/mem-22-e.xml
@@ -2199,7 +2199,7 @@ This word should not be confused with {'eQway:n}.</column>
       <column name="entry_name">'e'</column>
       <column name="part_of_speech">n:pro</column>
       <column name="definition">that (previous topic)</column>
-      <column name="definition_de">das, welches (voriges Thema)</column>
+      <column name="definition_de">das (voriges Thema)</column>
       <column name="definition_fa">که (موضوع قبلی) [AUTOTRANSLATED]</column>
       <column name="definition_sv">det (föregående ämne)</column>
       <column name="definition_ru">что (предыдущая тема)</column>
@@ -2228,7 +2228,7 @@ Do not confuse this pronoun with the suffix {-'e':n:suff}.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="search_tags"></column>
-      <column name="search_tags_de"></column>
+      <column name="search_tags_de">dass</column>
       <column name="search_tags_fa"></column>
       <column name="search_tags_sv"></column>
       <column name="search_tags_ru"></column>


### PR DESCRIPTION
only "das" can be switched with "welches" in a sentence. Perhaps even add "dies" to the german translation? "dies" and "welches" are both potential replacements for a "das", but never for a "dass".