### PR TITLE
jonta' -> en: engine -> de: Antrieb, Motor

### DIFF
--- a/mem-06-j.xml
+++ b/mem-06-j.xml
@@ -5170,7 +5170,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="entry_name">jonta'</column>
       <column name="part_of_speech">n</column>
       <column name="definition">engine</column>
-      <column name="definition_de">Maschine</column>
+      <column name="definition_de">Antrieb, Motor</column>
       <column name="definition_fa">موتور [AUTOTRANSLATED]</column>
       <column name="definition_sv">maskin</column>
       <column name="definition_ru"></column>


### PR DESCRIPTION
jonta' is currently translated as "Maschine" in german - while not wrong, it's misleading. "Maschine" literally means "machine", which could be anything from a coffee-maker to a robot.
I think a better translation might be "Antrieb, Motor", although those may be misleading as well ("propulsion system", "motor").
Maybe add as a note that in the movie it referred to the spaceship's propulsion?