### PR TITLE
DIj - use pigment stick ON something

### DIFF
--- a/mem-03-D.xml
+++ b/mem-03-D.xml
@@ -4334,8 +4334,8 @@ Watch Gowron say this: {YouTube video:url:http://youtu.be/7qXuTn9HpP4}</column>
       <column name="_id"></column>
       <column name="entry_name">DIj</column>
       <column name="part_of_speech">v:2,t_c</column>
-      <column name="definition">use a pigment stick, paint with pigment stick</column>
-      <column name="definition_de">malen mit Malstab</column>
+      <column name="definition">use a pigment stick on sth., paint sth. with pigment stick</column>
+      <column name="definition_de">malen mit Malstab auf</column>
       <column name="definition_fa">استفاده از چوب رنگدانه، رنگ با چوب رنگدانه [AUTOTRANSLATED]</column>
       <column name="definition_sv">använda en pigmentpinne, måla med pigmentpinne</column>
       <column name="definition_ru"></column>


### PR DESCRIPTION
I think adding "on" to the translation makes it more obvious that the object is the thing covered in paint, not the thing being painted. It's definite now, so it's best to remove ambiguity in the translation.

Please check the german as well - only adding "auf" seems crude, but adding "etwas" (something) seems weird...