### PR TITLE
letter b - mark German adjectives with "sein" (to be)

### DIFF
--- a/mem-01-b.xml
+++ b/mem-01-b.xml
@@ -441,7 +441,7 @@ Watch Gowron say this: {YouTube video:url:http://youtu.be/kWP0lgIYMBA}</column>
       <column name="entry_name">baHwI', DoS yIbuS. QuQ neH.</column>
       <column name="part_of_speech">sen:phr</column>
       <column name="definition">Gunner, target engine only.</column>
-      <column name="definition_de">Schütze, konzentriere dich auf das Ziel! Nur ausschalten.</column>
+      <column name="definition_de">Schütze, konzentriere dich auf das Ziel! Nur der Antrieb.</column>
       <column name="definition_fa">توپچی ها، فقط موتور هدف. [AUTOTRANSLATED]</column>
       <column name="definition_sv">Skytt, sikta bara på motorn!</column>
       <column name="definition_ru">Стрелок, целиться только в двигатели.</column>
@@ -1007,7 +1007,7 @@ Watch Gowron say this: {YouTube video:url:http://youtu.be/kWP0lgIYMBA}</column>
       <column name="entry_name">baQ</column>
       <column name="part_of_speech">v:2,is</column>
       <column name="definition">be fresh, be just picked (fruit, vegetable)</column>
-      <column name="definition_de">frisch, frisch geerntet (Obst oder Gemüse)</column>
+      <column name="definition_de">frisch sein, frisch geerntet sein (Obst oder Gemüse)</column>
       <column name="definition_fa">تازه، فقط برداشت می شود (میوه، سبزیجات) [AUTOTRANSLATED]</column>
       <column name="definition_sv">vara färsk, vara nyplockad (om frukt, grönsak)</column>
       <column name="definition_ru">быть свежим, быть только что собранным (фрукт, овощ)</column>
@@ -1226,7 +1226,7 @@ Watch Gowron say this: {YouTube video:url:http://youtu.be/kWP0lgIYMBA}</column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
       <column name="notes">The father of T'vis. See {tI'vIS:n}.</column>
-      <column name="notes_de"></column>
+      <column name="notes_de">Vater von T'vis. Siehe {tI'vIS:n}</column>
       <column name="notes_fa"></column>
       <column name="notes_sv"></column>
       <column name="notes_ru"></column>
@@ -1979,7 +1979,7 @@ Watch Gowron say this: {YouTube video:url:http://youtu.be/kWP0lgIYMBA}</column>
       <column name="entry_name">baw'</column>
       <column name="part_of_speech">v:is</column>
       <column name="definition">be comfortable, be feeling prepared, be confident</column>
-      <column name="definition_de">zuversichtlich, vorbereitet, sicher</column>
+      <column name="definition_de">zuversichtlich sein, vorbereitet sein, sicher sein</column>
       <column name="definition_fa">راحت باشید، آماده باشید، مطمئن باشید [AUTOTRANSLATED]</column>
       <column name="definition_sv">var bekväm, känner sig förberedd, var säker [AUTOTRANSLATED]</column>
       <column name="definition_ru">быть удобным, чуствовать себя готовым, быть уверенным в себе</column>
@@ -2435,7 +2435,7 @@ Watch Gowron say this: {YouTube video:url:http://youtu.be/kWP0lgIYMBA}</column>
       <column name="entry_name">bej</column>
       <column name="part_of_speech">v:2,is,slang</column>
       <column name="definition">be sure, be definite, be positive, be certain</column>
-      <column name="definition_de">sicher sein</column>
+      <column name="definition_de">sicher sein, definitiv sein, eindeutig sein</column>
       <column name="definition_fa">مطمئن باشید، مطمئن باشید، مثبت باشید، مطمئن باشید [AUTOTRANSLATED]</column>
       <column name="definition_sv">vara helt säker, vara viss</column>
       <column name="definition_ru">быть уверенным, быть точным, быть достоверным, быть надежным</column>
@@ -3043,7 +3043,7 @@ To say "when I was X years old", the construction is, for example, {qaStaHvIS DI
       <column name="entry_name">bergh</column>
       <column name="part_of_speech">v:is</column>
       <column name="definition">be irritable, be irritated</column>
-      <column name="definition_de">reizbar sein, gereizt</column>
+      <column name="definition_de">reizbar sein, gereizt sein</column>
       <column name="definition_fa">تحریک پذیر باشد، تحریک شود [AUTOTRANSLATED]</column>
       <column name="definition_sv">vara irritabel, vara lättretlig, vara retlig</column>
       <column name="definition_ru">быть раздражительным, быть раздраженным</column>
@@ -5375,7 +5375,7 @@ Watch Gowron say this: {YouTube video:url:http://youtu.be/NpFDKTzINH8}</column>
       <column name="entry_name">bIr</column>
       <column name="part_of_speech">v:is</column>
       <column name="definition">be cold</column>
-      <column name="definition_de">kalt</column>
+      <column name="definition_de">kalt sein</column>
       <column name="definition_fa">سرد بودن</column>
       <column name="definition_sv">vara kall</column>
       <column name="definition_ru">Быть холодным</column>
@@ -5904,7 +5904,7 @@ Watch Gowron say this: {YouTube video:url:http://youtu.be/NpFDKTzINH8}</column>
       <column name="entry_name">bIt</column>
       <column name="part_of_speech">v:is</column>
       <column name="definition">be nervous, uneasy</column>
-      <column name="definition_de">nervös, unruhig</column>
+      <column name="definition_de">nervös, unruhig sein</column>
       <column name="definition_fa">عصبی، ناراحت کننده بودن [AUTOTRANSLATED]</column>
       <column name="definition_sv">vara nervös, vara rastlös</column>
       <column name="definition_ru">Быть нервным, быть беспокойным</column>
@@ -6698,7 +6698,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="entry_name">boH</column>
       <column name="part_of_speech">v:is</column>
       <column name="definition">be impatient</column>
-      <column name="definition_de">ungeduldig</column>
+      <column name="definition_de">ungeduldig sein</column>
       <column name="definition_fa">ببخشید [AUTOTRANSLATED]</column>
       <column name="definition_sv">vara otålig</column>
       <column name="definition_ru">Быть нетерпеливым</column>
@@ -9208,7 +9208,7 @@ This can refer to a "category" (i.e., a related group) of {DuH:n} in a {SeHlaw:n
       <column name="entry_name">buy'</column>
       <column name="part_of_speech">v:is</column>
       <column name="definition">be full, be filled up</column>
-      <column name="definition_de">voll, gefüllt</column>
+      <column name="definition_de">voll sein, gefüllt sein</column>
       <column name="definition_fa">پر بودن</column>
       <column name="definition_sv">vara full, vara fylld</column>
       <column name="definition_ru">Быть наполненным, быть заполненным</column>

--- a/mem-01-b.xml
+++ b/mem-01-b.xml
@@ -1226,7 +1226,7 @@ Watch Gowron say this: {YouTube video:url:http://youtu.be/kWP0lgIYMBA}</column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
       <column name="notes">The father of T'vis. See {tI'vIS:n}.</column>
-      <column name="notes_de">Vater von T'vis. Siehe {tI'vIS:n}</column>
+      <column name="notes_de">Vater von T'vis. Siehe {tI'vIS:n}.</column>
       <column name="notes_fa"></column>
       <column name="notes_sv"></column>
       <column name="notes_ru"></column>


### PR DESCRIPTION
there is an inconsistency among to-be-verbs in german which are sometimes translated as only "adjective" instead of "be adjective".