### PR TITLE
add pun for nIl

### DIFF
--- a/mem-09-n.xml
+++ b/mem-09-n.xml
@@ -4058,7 +4058,7 @@ This verb is used to express the concept that two things have the same amount of
       <column name="entry_name">nIl</column>
       <column name="part_of_speech">v:is</column>
       <column name="definition">be grassy, verdant</column>
-      <column name="definition_de">grasig, grasbedeckt, begrünt</column>
+      <column name="definition_de">grasig sein, grasbedeckt sein, begrünt</column>
       <column name="definition_fa">گیلاس، سیب زمینی [AUTOTRANSLATED]</column>
       <column name="definition_sv">vara gräsbevuxna, gröna [AUTOTRANSLATED]</column>
       <column name="definition_ru"></column>
@@ -4072,7 +4072,7 @@ This verb is used to express the concept that two things have the same amount of
       <column name="notes_sv"></column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
-      <column name="hidden_notes"></column>
+      <column name="hidden_notes">The Nile valley is the most verdant area in Egypt.</column>
       <column name="components"></column>
       <column name="examples">{puH nIl:n}</column>
       <column name="examples_de"></column>

--- a/mem-09-n.xml
+++ b/mem-09-n.xml
@@ -4072,7 +4072,7 @@ This verb is used to express the concept that two things have the same amount of
       <column name="notes_sv"></column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
-      <column name="hidden_notes">The Nile valley is the most verdant area in Egypt.</column>
+      <column name="hidden_notes">Neil deGrasse Tyson is an American astrophysicist.</column>
       <column name="components"></column>
       <column name="examples">{puH nIl:n}</column>
       <column name="examples_de"></column>


### PR DESCRIPTION
This is not confirmed by Okrand, but seems quite obvious to me, unless there are more obvious reasons. For your interest, in German, "Nile" is written "Nil" and pronounced as the English name "Neal".