### PR TITLE
"loch", verb, german must include "sein" => ein Teil (von ewas) sein

### DIFF
--- a/mem-07-l.xml
+++ b/mem-07-l.xml
@@ -4445,7 +4445,7 @@ This was used to refer to "variables" (a memory location used for storing data i
       <column name="entry_name">loch</column>
       <column name="part_of_speech">v:t_c</column>
       <column name="definition">be a fraction of, make up a portion of, constitute part of</column>
-      <column name="definition_de">Teil von, Teilmenge von</column>
+      <column name="definition_de">ein Teil (von etwas) sein, eine Teilmenge (von etwas) sein</column>
       <column name="definition_fa"></column>
       <column name="definition_sv"></column>
       <column name="definition_ru"></column>


### PR DESCRIPTION
I'd say that any english verb definition containing "be" would likely include a "sein" in the german, to differentiate it from a noun. Maybe there's a way to automatically look for that?
(I'll think about it as well, but I wanted to mention it, just in case.)