### PR TITLE
'om "fend off" => abwehren

### DIFF
--- a/mem-24-o.xml
+++ b/mem-24-o.xml
@@ -623,7 +623,7 @@ A verb commonly used with {'olQan:n:nolink} is {'uch:v:1}.</column>
       <column name="entry_name">'om</column>
       <column name="part_of_speech">v:t_c</column>
       <column name="definition">resist, fend off</column>
-      <column name="definition_de">widerstehen</column>
+      <column name="definition_de">widerstehen, abwehren</column>
       <column name="definition_fa">مقاومت کردن [AUTOTRANSLATED]</column>
       <column name="definition_sv">motsätta sig, avvärja</column>
       <column name="definition_ru"></column>


### PR DESCRIPTION
"widerstehen" alleine übersetzt nur "resist", aber "fend off" wäre "abwehren", was die Bedeutung etwas ändert
(Ich kann einer Versuchung widerstehen, aber sie nicht abwehren. Ich kann einem Angriff widerstehen und ihn abwehren.)