### PR TITLE
fix autotranslated German words - b

### DIFF
--- a/mem-01-b.xml
+++ b/mem-01-b.xml
@@ -1543,7 +1543,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="entry_name">baSta'</column>
       <column name="part_of_speech">n</column>
       <column name="definition">vector</column>
-      <column name="definition_de">Vektor [AUTOTRANSLATED]</column>
+      <column name="definition_de">Vektor</column>
       <column name="definition_fa">وکتور [AUTOTRANSLATED]</column>
       <column name="definition_sv">vektor [AUTOTRANSLATED]</column>
       <column name="definition_ru">вектор [AUTOTRANSLATED]</column>
@@ -1553,7 +1553,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="antonyms"></column>
       <column name="see_also">{Quv:n}, {rober:n}, {roDSer:n}</column>
       <column name="notes">This is a mathematics term.</column>
-      <column name="notes_de">Dies ist ein mathematischer Begriff. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Dies ist ein mathematischer Begriff.</column>
       <column name="notes_fa">این یک اصطلاح ریاضی است. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Detta är en matematisk term. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это математический термин. [AUTOTRANSLATED]</column>
@@ -3720,7 +3720,7 @@ The {betleH:n:nolink} is also called the {betleH quv:n:nolink}, to differentiate
       <column name="entry_name">bettI'</column>
       <column name="part_of_speech">n</column>
       <column name="definition">aluminum</column>
-      <column name="definition_de">Aluminium [AUTOTRANSLATED]</column>
+      <column name="definition_de">Aluminium</column>
       <column name="definition_fa">آلومینیوم [AUTOTRANSLATED]</column>
       <column name="definition_sv">aluminium [AUTOTRANSLATED]</column>
       <column name="definition_ru">алюминий [AUTOTRANSLATED]</column>
@@ -3730,7 +3730,7 @@ The {betleH:n:nolink} is also called the {betleH quv:n:nolink}, to differentiate
       <column name="antonyms"></column>
       <column name="see_also">{baS:n}, {tamler:n}</column>
       <column name="notes">This is the metallic chemical element with the symbol Al and atomic number 13.</column>
-      <column name="notes_de">Dies ist das metallische chemische Element mit dem Symbol Al und der Ordnungszahl 13. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Dies ist das metallische chemische Element mit dem Symbol Al und der Ordnungszahl 13.</column>
       <column name="notes_fa">این عنصر شیمیایی فلزی با نماد Al و عدد اتمی 13 است. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Detta är det metalliska kemiska elementet med symbolen Al och atomnummer 13. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это металлический химический элемент с символом А1 и атомным номером 13. [AUTOTRANSLATED]</column>
@@ -5728,7 +5728,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="antonyms"></column>
           <column name="see_also"></column>
           <column name="notes">Historically or etymologically, this was no doubt formed from {bIQ SeHmeH jan:n} by dropping the {-meH:v}. This could happen for other words (e.g., {voD jan:n}), but is not a productive process. Except for some set, accepted expressions, dropping the {-meH:v:nolink} is considered odd, but people may do this anyway in everyday conversation. </column>
-          <column name="notes_de">Historisch oder etymologisch wurde dies zweifellos aus {bIQ SeHmeH jan:n} durch Ablegen des {-meH:v} gebildet. Dies könnte für andere Wörter (z. B. {voD jan:n}) passieren, ist jedoch kein produktiver Prozess. Abgesehen von einigen festgelegten, akzeptierten Ausdrücken wird das Löschen von {-meH:v:nolink} als seltsam angesehen, aber die Leute können dies trotzdem in alltäglichen Gesprächen tun. [AUTOTRANSLATED]</column>
+          <column name="notes_de">Historisch oder etymologisch wurde dies zweifellos aus {bIQ SeHmeH jan:n} durch Wegfall des {-meH:v} gebildet. Dies könnte auch für andere Wörter (wie z. B. {voD jan:n}) gelten, ist jedoch kein regelmäßiger Vorgang. Abgesehen von einigen festgelegten Ausdrücken wird das Weglassen von {-meH:v:nolink} als seltsam angesehen, man könnte es aber trotzdem im alltgäglichen Gespräch hören.</column>
           <column name="notes_fa">از لحاظ تاریخی یا اخلاقی ، این بدون شک از {bIQ SeHmeH jan:n} با انداختن {-meH:v} شکل گرفته است. این ممکن است برای کلمات دیگر (به عنوان مثال ، {voD jan:n}) اتفاق بیفتد ، اما یک روند تولیدی نیست. به جز برخی از اصطلاحات اصولی و پذیرفته شده ، انداختن {-meH:v:nolink} امری عجیب و غریب محسوب می شود ، اما ممکن است مردم در مکالمه روزمره این کار را انجام دهند. [AUTOTRANSLATED]</column>
           <column name="notes_sv">Historiskt eller etymologiskt bildades detta utan tvekan från {bIQ SeHmeH jan:n} genom att droppa {-meH:v}. Detta kan hända med andra ord (t.ex. {voD jan:n}), men är inte en produktiv process. Bortsett från vissa uppsatta, accepterade uttryck, är att släppa {-meH:v:nolink} anses konstigt, men människor kan göra det ändå i vardagliga samtal. [AUTOTRANSLATED]</column>
           <column name="notes_ru">Исторически или этимологически, это, без сомнения, было сформировано из {bIQ SeHmeH jan:n} путем удаления {-meH:v}. Это может произойти для других слов (например, {voD jan:n}), но это не продуктивный процесс. За исключением некоторого набора, принятых выражений, отбрасывание {-meH:v:nolink} считается странным, но люди могут делать это в любом случае в повседневной беседе. [AUTOTRANSLATED]</column>
@@ -8498,7 +8498,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
       <column name="entry_name">boqyIn</column>
       <column name="part_of_speech">n:deriv</column>
       <column name="definition">symbiont</column>
-      <column name="definition_de">Symbiont [AUTOTRANSLATED]</column>
+      <column name="definition_de">Symbiont</column>
       <column name="definition_fa">سیمینت [AUTOTRANSLATED]</column>
       <column name="definition_sv">symbiont [AUTOTRANSLATED]</column>
       <column name="definition_ru">симбионт [AUTOTRANSLATED]</column>
@@ -8508,7 +8508,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
       <column name="antonyms"></column>
       <column name="see_also">{tI'rIl:n}, {nungmaH:n}</column>
       <column name="notes">Which plural suffix this takes depends on the type of symbiont. In the case of Trill (see {tI'rIlngan:n}) symbionts, the suffix {-pu':n:suff} is used.</column>
-      <column name="notes_de">Welches Plural-Suffix dies erfordert, hängt von der Art des Symbionten ab. Bei Trill-Symbionten (siehe {tI'rIlngan:n}) wird das Suffix {-pu':n:suff} verwendet. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Die Wahl der Mehrzahl-Bildung hängt von der Art des Symbionten ab. Bei Trill-Symbionten (siehe {tI'rIlngan:n}) wird das Suffix {-pu':n:suff} verwendet. Falls es sich um einen Parasiten handelt, verwendet man {-mey:n:suff}.</column>
       <column name="notes_fa">کدام پسوند جمع در این مورد بستگی به نوع Symiont دارد. در مورد نمادهای تریل (نگاه کنید به {tI'rIlngan:n}) از پسوند {-pu':n:suff} استفاده می شود. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Vilket flertalssuffiks detta tar beror på typen av symbiont. När det gäller Trill (se {tI'rIlngan:n}) -symbioner används suffixet {-pu':n:suff}. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Какой суффикс множественного числа это принимает, зависит от типа симбионта. В случае симбионтов Trill (см. {tI'rIlngan:n}) используется суффикс {-pu':n:suff}. [AUTOTRANSLATED]</column>
@@ -9471,7 +9471,7 @@ This word is used in the idioms {bo'Dagh'a' lo':sen} and {bo'DaghHom lo':sen}.</
       <column name="antonyms"></column>
       <column name="see_also">{ghIpDIj:v}, {bo'DIj pa':n}, {bo'DIj qach:n}, {bo'DIj qaD:n}</column>
       <column name="notes">This refers to the institution of the court, a judicial organization.</column>
-      <column name="notes_de">Dies bezieht sich auf die Einrichtung des Gerichts, einer Justizorganisation. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Dies bezieht sich auf die Einrichtung des Gerichts, einer Justizorganisation.</column>
       <column name="notes_fa">این مربوط به نهاد دادگاه ، یک سازمان قضایی است. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Detta avser institutionens domstol, en rättslig organisation. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это относится к институту суда, судебной организации. [AUTOTRANSLATED]</column>
@@ -9617,7 +9617,7 @@ This word is used in the idioms {bo'Dagh'a' lo':sen} and {bo'DaghHom lo':sen}.</
           <column name="entry_name">bo'DIj qaD</column>
           <column name="part_of_speech">n:deriv</column>
           <column name="definition">lawsuit</column>
-          <column name="definition_de">Klage [AUTOTRANSLATED]</column>
+          <column name="definition_de">Klage, Anklage (gerichtlich)</column>
           <column name="definition_fa">طرح دعوی در دادگاه [AUTOTRANSLATED]</column>
           <column name="definition_sv">rättegång [AUTOTRANSLATED]</column>
           <column name="definition_ru">судебный процесс [AUTOTRANSLATED]</column>
@@ -9818,7 +9818,7 @@ The Story of the Promise states that:
       <column name="entry_name">buj</column>
       <column name="part_of_speech">v:is</column>
       <column name="definition">be neither warm nor cool (temperature)</column>
-      <column name="definition_de">sei weder warm noch kalt (Temperatur) [AUTOTRANSLATED]</column>
+      <column name="definition_de">weder warm noch kalt sein (Temperatur)</column>
       <column name="definition_fa">نه گرم باشد و نه خنک (دما) [AUTOTRANSLATED]</column>
       <column name="definition_sv">vara varken varm eller sval (temperatur) [AUTOTRANSLATED]</column>
       <column name="definition_ru">не быть ни теплым, ни прохладным (температура) [AUTOTRANSLATED]</column>
@@ -9898,7 +9898,7 @@ It was clarified during the Q &amp; A session that the temperature words really 
       <column name="entry_name">bum</column>
       <column name="part_of_speech">v:t_c</column>
       <column name="definition">absorb</column>
-      <column name="definition_de">absorbieren [AUTOTRANSLATED]</column>
+      <column name="definition_de">absorbieren</column>
       <column name="definition_fa">جذب [AUTOTRANSLATED]</column>
       <column name="definition_sv">absorbera [AUTOTRANSLATED]</column>
       <column name="definition_ru">абсорбировать [AUTOTRANSLATED]</column>
@@ -9908,7 +9908,7 @@ It was clarified during the Q &amp; A session that the temperature words really 
       <column name="antonyms"></column>
       <column name="see_also">{betgham:n}, {Hal:v}</column>
       <column name="notes">This refers to the sense of a towel absorbing liquid. It is not used in the sense of absorbing information.</column>
-      <column name="notes_de">Dies bezieht sich auf den Sinn einer Handtuch absorbierenden Flüssigkeit. Es wird nicht im Sinne der Informationsaufnahme verwendet. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Dies bezieht sich auf das Absorbieren einer Flüssigkeit durch ein Handtuch. Es wird nicht im Sinne von Informationsaufnahme verwendet.</column>
       <column name="notes_fa">این به حس مایع جذب حوله اشاره دارد. از آن به معنای جذب اطلاعات استفاده نمی شود. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Detta avser känslan av en handdukabsorberande vätska. Det används inte i den meningen att absorbera information. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это относится к ощущению жидкости, поглощающей полотенце. Он не используется в смысле поглощения информации. [AUTOTRANSLATED]</column>
@@ -10377,7 +10377,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="entry_name">butnat</column>
       <column name="part_of_speech">n</column>
       <column name="definition">plutonium</column>
-      <column name="definition_de">Plutonium [AUTOTRANSLATED]</column>
+      <column name="definition_de">Plutonium</column>
       <column name="definition_fa">پلوتونیوم [AUTOTRANSLATED]</column>
       <column name="definition_sv">plutonium [AUTOTRANSLATED]</column>
       <column name="definition_ru">плутоний [AUTOTRANSLATED]</column>
@@ -10387,7 +10387,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="antonyms"></column>
       <column name="see_also">{boq:n:2}, {tamler:n}, {woj:n}, {tlhuD:v}</column>
       <column name="notes">This is the radioactive chemical element with the symbol Pu and atomic number 94.</column>
-      <column name="notes_de">Dies ist das radioaktive chemische Element mit dem Symbol Pu und der Ordnungszahl 94. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Dies ist das radioaktive Element mit dem Symbol Pu und der Ordnungszahl 94.</column>
       <column name="notes_fa">این عنصر شیمیایی رادیواکتیو با نماد Pu و عدد اتمی 94 است. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Detta är det radioaktiva kemiska elementet med symbolen Pu och atomnummer 94. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это радиоактивный химический элемент с символом Pu и атомным номером 94. [AUTOTRANSLATED]</column>


### PR DESCRIPTION
correct autotranslated German entries for letter b, only new words from qep'a'.