### PR TITLE
fix new words in German letter j

### DIFF
--- a/mem-06-j.xml
+++ b/mem-06-j.xml
@@ -130,7 +130,7 @@
       <column name="antonyms"></column>
       <column name="see_also"></column>
       <column name="notes">This is the name of a cookbook by J'puq.[1, p.86]</column>
-      <column name="notes_de"></column>
+      <column name="notes_de">Dies ist der Titel eines Kochbuchs von J'puq.[1, p.86]</column>
       <column name="notes_fa">این نام کتاب آشپزی توسط J'puq.[1, p.86] است [AUTOTRANSLATED]</column>
       <column name="notes_sv">Detta är namnet på en kokbok av J'puq.[1, p.86] [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это название книги рецептов, автором которой является J'puq.[1, стр.86]</column>
@@ -171,7 +171,7 @@ The title of the book may be a reference to the Twilight Zone episode "To Serve 
       <column name="antonyms"></column>
       <column name="see_also">{chom:n}, {tebwI':n}, {vutwI':n}</column>
       <column name="notes">It is the duty of the {jabwI':n:nolink} to {qaw:v} the order.</column>
-      <column name="notes_de">Es ist die Pflicht des {jabwI':n:nolink}, die Bestellung zu {qaw:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Es ist die Pflicht des {jabwI':n:nolink}, sich an die Bestellung zu {qaw:v}.</column>
       <column name="notes_fa">این وظیفه {jabwI':n:nolink} است که {qaw:v} را سفارش دهد. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Det är {jabwI':n:nolink}: s skyldighet att beställa {qaw:v}. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это обязанность {jabwI':n:nolink} к {qaw:v} заказа. [AUTOTRANSLATED]</column>
@@ -359,7 +359,7 @@ To juggle, that is, to throw objects into the air and catch them in a rhythmic p
       <column name="entry_name">jaDchu'</column>
       <column name="part_of_speech">v:t_c,deriv</column>
       <column name="definition">juggle (objects, not tasks)</column>
-      <column name="definition_de">Jonglieren (mit Gegenständen)</column>
+      <column name="definition_de">jonglieren (mit Gegenständen)</column>
       <column name="definition_fa">قاچاق (اشیاء، وظایف) [AUTOTRANSLATED]</column>
       <column name="definition_sv">jonglera (objekt, inte uppgifter) [AUTOTRANSLATED]</column>
       <column name="definition_ru">juggle (objects, not tasks) [AUTOTRANSLATED]</column>
@@ -892,7 +892,7 @@ For "days ago" and "days from now", see {Hu':n} and {leS:n}, respectively.</colu
       <column name="antonyms"></column>
       <column name="see_also">{'uSgheb:n}</column>
       <column name="notes">The verb {jach:v} can describe what a {jajlo' Qa':n:nolink} does.</column>
-      <column name="notes_de">Das Verb {jach:v} kann beschreiben, was ein {jajlo' Qa':n:nolink} tut. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Das Verb {jach:v} kann beschreiben, was ein {jajlo' Qa':n:nolink} tut.</column>
       <column name="notes_fa"></column>
       <column name="notes_sv">Verbetet {jach:v} kan beskriva vad en {jajlo' Qa':n:nolink} gör. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Глагол {jach:v} может описывать, что делает {jajlo' Qa':n:nolink}. [AUTOTRANSLATED]</column>
@@ -3396,7 +3396,7 @@ Note that {jemS:n:nolink} and {qIrq:n:nolink} do not follow proper Klingon phono
       <column name="entry_name">jergh</column>
       <column name="part_of_speech">v:i_c</column>
       <column name="definition">spasm</column>
-      <column name="definition_de">Krampf [AUTOTRANSLATED]</column>
+      <column name="definition_de">krampfen</column>
       <column name="definition_fa">اسپاسم [AUTOTRANSLATED]</column>
       <column name="definition_sv">spasm [AUTOTRANSLATED]</column>
       <column name="definition_ru">спазм [AUTOTRANSLATED]</column>
@@ -3406,7 +3406,7 @@ Note that {jemS:n:nolink} and {qIrq:n:nolink} do not follow proper Klingon phono
       <column name="antonyms"></column>
       <column name="see_also">{ghan'ach:n}</column>
       <column name="notes">To cause something to spasm is {jerghmoH:v@@jergh:v, -moH:v}.</column>
-      <column name="notes_de">Etwas zu verkrampfen ist {jerghmoH:v@@jergh:v, -moH:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Etwas zum Krampfen zu bringen ist {jerghmoH:v@@jergh:v, -moH:v}.</column>
       <column name="notes_fa">برای ایجاد اسپاسم ، {jerghmoH:v@@jergh:v, -moH:v} است. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Att få något att krascha är {jerghmoH:v@@jergh:v, -moH:v}. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Причинять что-то к спазму {jerghmoH:v@@jergh:v, -moH:v}. [AUTOTRANSLATED]</column>
@@ -3959,7 +3959,7 @@ This verb is used in Sonnet 116, where its explicit subject is {muD:n:nolink}.[2
       <column name="entry_name">je'ton</column>
       <column name="part_of_speech">n</column>
       <column name="definition">counter, workbench</column>
-      <column name="definition_de">Theke, Werkbank [AUTOTRANSLATED]</column>
+      <column name="definition_de">Theke, Werkbank</column>
       <column name="definition_fa">پیشخوان ، میز کار [AUTOTRANSLATED]</column>
       <column name="definition_sv">räknare, arbetsbänk [AUTOTRANSLATED]</column>
       <column name="definition_ru">счетчик, верстак [AUTOTRANSLATED]</column>
@@ -3969,7 +3969,7 @@ This verb is used in Sonnet 116, where its explicit subject is {muD:n:nolink}.[2
       <column name="antonyms"></column>
       <column name="see_also">{raS:n}</column>
       <column name="notes">This is a work space attached to the wall.</column>
-      <column name="notes_de">Dies ist ein an der Wand befestigter Arbeitsbereich. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Dies ist ein an der Wand befestigter Arbeitsbereich.</column>
       <column name="notes_fa">این یک فضای کار متصل به دیوار است. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Detta är ett arbetsutrymme fäst på väggen. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это рабочее место, прикрепленное к стене. [AUTOTRANSLATED]</column>
@@ -4746,7 +4746,7 @@ To express a wish for something to happen, see {-jaj:v}.</column>
       <column name="entry_name">jInay'</column>
       <column name="part_of_speech">n:place</column>
       <column name="definition">J'naii (planet)</column>
-      <column name="definition_de">J'naii (Planet) [AUTOTRANSLATED]</column>
+      <column name="definition_de">J'naii (Planet)</column>
       <column name="definition_fa">جنایی (سیاره) [AUTOTRANSLATED]</column>
       <column name="definition_sv">J'naii (planet) [AUTOTRANSLATED]</column>
       <column name="definition_ru">J'naii (планета) [AUTOTRANSLATED]</column>
@@ -4754,7 +4754,7 @@ To express a wish for something to happen, see {-jaj:v}.</column>
       <column name="definition_pt">J'naii (planeta)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
-      <column name="see_also"></column>
+      <column name="see_also">{jInay'ngan:n}</column>
       <column name="notes"></column>
       <column name="notes_de"></column>
       <column name="notes_fa"></column>
@@ -4762,7 +4762,7 @@ To express a wish for something to happen, see {-jaj:v}.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
-      <column name="hidden_notes">Presumably, a J'naii (a member of the humanoid species native to the planet) would be a {jInay'ngan:n@@jInay':n, ngan:n}, but this was not stated.</column>
+      <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
       <column name="examples_de"></column>
@@ -4785,7 +4785,7 @@ To express a wish for something to happen, see {-jaj:v}.</column>
           <column name="entry_name">jInay'ngan</column>
           <column name="part_of_speech">n:being,fic,deriv</column>
           <column name="definition">J'naii (person)</column>
-          <column name="definition_de">J'naii (Person) [AUTOTRANSLATED]</column>
+          <column name="definition_de">J'naii (Person)</column>
           <column name="definition_fa">جنایی (شخص) [AUTOTRANSLATED]</column>
           <column name="definition_sv">J'naii (person) [AUTOTRANSLATED]</column>
           <column name="definition_ru">J'naii (человек) [AUTOTRANSLATED]</column>
@@ -5058,7 +5058,7 @@ To express a wish for something to happen, see {-jaj:v}.</column>
       <column name="entry_name">jIrmoH</column>
       <column name="part_of_speech">v:2,t_c,deriv</column>
       <column name="definition">crank</column>
-      <column name="definition_de">Kurbel [AUTOTRANSLATED]</column>
+      <column name="definition_de">kurbeln</column>
       <column name="definition_fa">میل لنگ [AUTOTRANSLATED]</column>
       <column name="definition_sv">vev [AUTOTRANSLATED]</column>
       <column name="definition_ru">кривошип [AUTOTRANSLATED]</column>
@@ -5109,7 +5109,7 @@ To express a wish for something to happen, see {-jaj:v}.</column>
       <column name="antonyms"></column>
       <column name="see_also">{jISaHbe'.:sen}, {jIr:v}</column>
       <column name="notes">This is used to express that one is not exactly impressed by what someone has just said.</column>
-      <column name="notes_de">Dies wird verwendet, um auszudrücken, dass man nicht genau beeindruckt ist von dem, was jemand gerade gesagt hat. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Dies wird verwendet, um auszudrücken, dass man nicht wirklich beeindruckt ist von dem, was jemand gerade gesagt hat.</column>
       <column name="notes_fa">این مورد برای بیان اینکه شخصاً تحت تأثیر آنچه فقط کسی گفته است تأثیر نمی گذارد. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Detta används för att uttrycka att man inte exakt är imponerad av vad någon just har sagt. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это используется, чтобы выразить, что кто-то не совсем впечатлен тем, что кто-то только что сказал. [AUTOTRANSLATED]</column>
@@ -7347,7 +7347,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="entry_name">joSraD</column>
       <column name="part_of_speech">n</column>
       <column name="definition">crater</column>
-      <column name="definition_de">Krater [AUTOTRANSLATED]</column>
+      <column name="definition_de">Krater</column>
       <column name="definition_fa">دهانه [AUTOTRANSLATED]</column>
       <column name="definition_sv">krater [AUTOTRANSLATED]</column>
       <column name="definition_ru">кратер [AUTOTRANSLATED]</column>
@@ -7373,7 +7373,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
       <column name="search_tags"></column>
-      <column name="search_tags_de"></column>
+      <column name="search_tags_de">Laach</column>
       <column name="search_tags_fa"></column>
       <column name="search_tags_sv"></column>
       <column name="search_tags_ru"></column>
@@ -7435,7 +7435,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="antonyms"></column>
       <column name="see_also">{jot:v:1}</column>
       <column name="notes">This is an archaic and upper-class word with the same meaning as {tlhorghHa':v}.</column>
-      <column name="notes_de">Dies ist ein archaisches und hochklassiges Wort mit der gleichen Bedeutung wie {tlhorghHa':v}. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Dies ist ein archaisches und hochklassiges Wort mit der gleichen Bedeutung wie {tlhorghHa':v}.</column>
       <column name="notes_fa">این یک کلمه باستانی و طبقه بالا با همان معنی {tlhorghHa':v} است. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Detta är ett arkaiskt och överklassord med samma betydelse som {tlhorghHa':v}. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это архаичное и высшее слово, имеющее то же значение, что и {tlhorghHa':v}. [AUTOTRANSLATED]</column>
@@ -7513,7 +7513,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="antonyms">{jotlhHa':v}</column>
       <column name="see_also">{teq:v}, {lel:v}</column>
       <column name="notes">This means to take an object down off a shelf or other overhead structure.</column>
-      <column name="notes_de">Dies bedeutet, ein Objekt von einem Regal oder einer anderen Überkopfstruktur abzunehmen. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Dies bedeutet, etwas von einem Regal oder einer anderen hohen Ebene herunterzunehmen.</column>
       <column name="notes_fa">این بدان معناست که یک شیء را از قفسه یا ساختار سربار دیگر خارج کنید. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Detta innebär att ta ett föremål ner från en hylla eller annan overheadstruktur. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это означает снять предмет с полки или другой конструкции. [AUTOTRANSLATED]</column>
@@ -8117,7 +8117,7 @@ If {-Daq:n} is used, it implies a miss: air was blown towards the object, but by
       <column name="antonyms"></column>
       <column name="see_also">{muD Dotlh:n}, {DIS:n:2}, {bav:v}, {yuQ:n}, {maS:n}, {namchIl:n}</column>
       <column name="notes">See {wov:v} for how to describe a sunny day.</column>
-      <column name="notes_de">Unter {wov:v} finden Sie Informationen zur Beschreibung eines sonnigen Tages. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Unter {wov:v} befinden sich Informationen zur Beschreibung eines sonnigen Tages.</column>
       <column name="notes_fa">برای توصیف یک روز آفتابی به {wov:v} مراجعه کنید. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Se {wov:v} för hur du beskriver en solig dag. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Смотрите {wov:v}, чтобы описать солнечный день. [AUTOTRANSLATED]</column>
@@ -8156,7 +8156,7 @@ If {-Daq:n} is used, it implies a miss: air was blown towards the object, but by
       <column name="antonyms"></column>
       <column name="see_also">{SIp:n}, {tamler:n}</column>
       <column name="notes">This literally means "sun gas".</column>
-      <column name="notes_de">Dies bedeutet wörtlich "Sonnengas". [AUTOTRANSLATED]</column>
+      <column name="notes_de">Dies bedeutet wörtlich "Sonnengas".</column>
       <column name="notes_fa">این به معنای واقعی کلمه به معنای "گاز خورشید" است. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Detta betyder bokstavligen "solgas". [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это дословно значит "Солнечный газ"</column>


### PR DESCRIPTION
fix autotranslated German entries for qep'a' 27 words, plus some others I noticed while editing.
I removed the hidden note at jInay for ngan because it said it was not confirmed, but the entry jInay'ngan includes the confirmation.