### PR TITLE
fix new words in German letter l

### DIFF
--- a/mem-07-l.xml
+++ b/mem-07-l.xml
@@ -1885,7 +1885,7 @@ The following example shows that the verb of quality can take a suffix:
       <column name="entry_name">lech</column>
       <column name="part_of_speech">v:t_c</column>
       <column name="definition">blackmail</column>
-      <column name="definition_de">Erpressung [AUTOTRANSLATED]</column>
+      <column name="definition_de">erpressen</column>
       <column name="definition_fa">باج خواهی [AUTOTRANSLATED]</column>
       <column name="definition_sv">utpressning [AUTOTRANSLATED]</column>
       <column name="definition_ru">шантажировать [AUTOTRANSLATED]</column>
@@ -1895,7 +1895,7 @@ The following example shows that the verb of quality can take a suffix:
       <column name="antonyms"></column>
       <column name="see_also">{buQ:v}</column>
       <column name="notes">The object of this verb is the victim of blackmail.</column>
-      <column name="notes_de">Das Objekt dieses Verbs ist das Opfer der Erpressung. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Das Objekt dieses Verbs ist das Opfer der Erpressung.</column>
       <column name="notes_fa">هدف این فعل قربانی باج خواهی است. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Syftet med detta verb är offer för utpressning. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Объект этого глагола является жертвой шантажа. [AUTOTRANSLATED]</column>
@@ -2856,7 +2856,7 @@ For movement to the side without rotation or being fixed to a point, see {Dav:v:
       <column name="entry_name">lervaD</column>
       <column name="part_of_speech">n</column>
       <column name="definition">auction</column>
-      <column name="definition_de">Versteigerung [AUTOTRANSLATED]</column>
+      <column name="definition_de">Versteigerung, Auktion</column>
       <column name="definition_fa">حراج [AUTOTRANSLATED]</column>
       <column name="definition_sv">auktion [AUTOTRANSLATED]</column>
       <column name="definition_ru">аукцион [AUTOTRANSLATED]</column>
@@ -3170,7 +3170,7 @@ This word can be used figuratively. There is an idiom, {let mInDu'Daj; Separmey 
       <column name="entry_name">letbIng</column>
       <column name="part_of_speech">n</column>
       <column name="definition">mercury</column>
-      <column name="definition_de">Merkur [AUTOTRANSLATED]</column>
+      <column name="definition_de">Quecksilber</column>
       <column name="definition_fa">سیاره تیر [AUTOTRANSLATED]</column>
       <column name="definition_sv">kvicksilver [AUTOTRANSLATED]</column>
       <column name="definition_ru">Меркурий [AUTOTRANSLATED]</column>
@@ -3180,7 +3180,7 @@ This word can be used figuratively. There is an idiom, {let mInDu'Daj; Separmey 
       <column name="antonyms"></column>
       <column name="see_also">{tamler:n}</column>
       <column name="notes">This is the metallic chemical element with the symbol Hg and atomic number 80.</column>
-      <column name="notes_de">Dies ist das metallische chemische Element mit dem Symbol Hg und der Ordnungszahl 80. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Dies ist das metallische chemische Element mit dem Symbol Hg und der Ordnungszahl 80.</column>
       <column name="notes_fa">این عنصر شیمیایی فلزی با نماد Hg و عدد اتمی 80 است. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Detta är det metalliska kemiska elementet med symbolen Hg och atomnummer 80. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это металлический химический элемент с символом Hg и атомным номером 80. [AUTOTRANSLATED]</column>
@@ -4771,7 +4771,7 @@ When a computer (or computer system) is online, it's said to be "sharing". See {
       <column name="entry_name">lIvrI'</column>
       <column name="part_of_speech">n</column>
       <column name="definition">granite</column>
-      <column name="definition_de">Granit [AUTOTRANSLATED]</column>
+      <column name="definition_de">Granit</column>
       <column name="definition_fa">سنگ گرانیت [AUTOTRANSLATED]</column>
       <column name="definition_sv">granit [AUTOTRANSLATED]</column>
       <column name="definition_ru">гранит [AUTOTRANSLATED]</column>
@@ -4851,7 +4851,7 @@ This was used to refer to "variables" (a memory location used for storing data i
           <column name="entry_name">lIw mu'</column>
           <column name="part_of_speech">n:deriv</column>
           <column name="definition">pronoun</column>
-          <column name="definition_de">Pronomen [AUTOTRANSLATED]</column>
+          <column name="definition_de">Pronomen</column>
           <column name="definition_fa">ضمیر [AUTOTRANSLATED]</column>
           <column name="definition_sv">pronomen [AUTOTRANSLATED]</column>
           <column name="definition_ru">местоимение [AUTOTRANSLATED]</column>
@@ -4861,7 +4861,7 @@ This was used to refer to "variables" (a memory location used for storing data i
           <column name="antonyms"></column>
           <column name="see_also"></column>
           <column name="notes">This applies to full words only, not prefixes (which are {moHaq:n}).</column>
-          <column name="notes_de">Dies gilt nur für vollständige Wörter, nicht für Präfixe (die {moHaq:n} sind). [AUTOTRANSLATED]</column>
+          <column name="notes_de">Dies gilt nur für vollständige Wörter, nicht für Präfixe (die {moHaq:n} sind).</column>
           <column name="notes_fa">این فقط مربوط به کلمات کامل است ، نه پیشوندها (که {moHaq:n} هستند). [AUTOTRANSLATED]</column>
           <column name="notes_sv">Detta gäller endast fullständiga ord, inte prefix (som är {moHaq:n}). [AUTOTRANSLATED]</column>
           <column name="notes_ru">Это относится только к полным словам, а не к префиксам ({moHaq:n}). [AUTOTRANSLATED]</column>
@@ -8912,7 +8912,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="entry_name">luqlev</column>
       <column name="part_of_speech">n</column>
       <column name="definition">curfew</column>
-      <column name="definition_de">Sperrstunde [AUTOTRANSLATED]</column>
+      <column name="definition_de">Sperrstunde</column>
       <column name="definition_fa">مقررات حکومت نظامی وخاموشی در ساعت معین شب [AUTOTRANSLATED]</column>
       <column name="definition_sv">utegångsförbud [AUTOTRANSLATED]</column>
       <column name="definition_ru">комендантский час [AUTOTRANSLATED]</column>
@@ -9130,7 +9130,7 @@ Ao se referir aos lados esquerdo e direito, são utilizados sufixos possessivos.
       <column name="antonyms"></column>
       <column name="see_also">{be'etor:n:name}, {DuraS:n:name}</column>
       <column name="notes">Sister of B'Etor and Duras. She is portrayed by the actress {barbara' ma'rIch:n:name}.</column>
-      <column name="notes_de">Schwester von B'Etor und Duras. Sie wird von der Schauspielerin {barbara' ma'rIch:n:name} porträtiert. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Schwester von B'Etor und Duras. Sie wird von der Schauspielerin {barbara' ma'rIch:n:name} dargestellt.</column>
       <column name="notes_fa">خواهر B'Etor و دوراس. او توسط بازیگر {barbara' ma'rIch:n:name} به تصویر کشیده شده است. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Syster till B'Etor och Duras. Hon framställs av skådespelerskan {barbara' ma'rIch:n:name}. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Сестра БеТор и Дюраса. Она сыграна актрисой {barbara' ma'rIch:n:name}.</column>


### PR DESCRIPTION
fix autotranslated German entries for qep'a' 27 words, plus some others I noticed while editing.