### PR TITLE
fix new words in German / loanwords

### DIFF
--- a/mem-27-extra.xml
+++ b/mem-27-extra.xml
@@ -874,7 +874,7 @@ The speech concludes with the words (in Federation Standard): "We come in peace.
       <column name="antonyms"></column>
       <column name="see_also">{tlhIngan maH!:sen}</column>
       <column name="notes">This literally means "We are Klingon, may it continue". The English subtitles render this as "Remain Klingon!"</column>
-      <column name="notes_de">Dies bedeutet wörtlich "Wir sind Klingonen, möge es weitergehen". Die englischen Untertitel geben dies als "Klingonen bleiben!"</column>
+      <column name="notes_de">Dies bedeutet wörtlich "Wir sind Klingonen, möge es weitergehen". Die englischen Untertitel geben dies als "Remain Klingon!"</column>
       <column name="notes_fa">این به معنای واقعی کلمه به معنای "ما کلینگون هستیم ، ممکن است ادامه یابد" باشد. زیرنویس های انگلیسی این جمله را "Remain Klingon!" [AUTOTRANSLATED]</column>
       <column name="notes_sv">Detta betyder bokstavligen "Vi är Klingon, får det fortsätta". De engelska undertexterna återger detta som "Remain Klingon!" [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это буквально означает «мы клингон, пусть так и будет». Английские субтитры отображают это как «Remain Klingon!» [AUTOTRANSLATED]</column>

--- a/mem-27-extra.xml
+++ b/mem-27-extra.xml
@@ -574,7 +574,7 @@ To address a single person, say {qatlh choneH?:sen@@qatlh:ques, cho-:v, neH:v}</
       <column name="antonyms"></column>
       <column name="see_also"></column>
       <column name="notes">This can also mean "Secure her!" or "Secure it!"</column>
-      <column name="notes_de">Dies kann auch bedeuten "Sichern Sie sie!" oder "Sichern Sie es!" [AUTOTRANSLATED]</column>
+      <column name="notes_de">Dies kann auch bedeuten "Sichern Sie sie!" oder "Sichern Sie es!"</column>
       <column name="notes_fa">این همچنین می تواند به معنای "ایمن کردن او" باشد. یا "آن را ایمن کنید!" [AUTOTRANSLATED]</column>
       <column name="notes_sv">Detta kan också betyda "Säkra henne!" eller "Säkra det!" [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это также может означать «Защити ее!» или "Защити это!" [AUTOTRANSLATED]</column>
@@ -613,7 +613,7 @@ To address a single person, say {qatlh choneH?:sen@@qatlh:ques, cho-:v, neH:v}</
       <column name="antonyms"></column>
       <column name="see_also"></column>
       <column name="notes">This literally means "aim weapons on this section".</column>
-      <column name="notes_de">Dies bedeutet wörtlich "Waffen auf diesen Abschnitt richten". [AUTOTRANSLATED]</column>
+      <column name="notes_de">Dies bedeutet wörtlich "Waffen auf diesen Abschnitt richten".</column>
       <column name="notes_fa">این به معنای واقعی کلمه به معنای "هدف قرار دادن سلاح ها در این بخش" است. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Detta betyder bokstavligen "rikta vapen på detta avsnitt". [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это буквально означает «нацелить оружие на этот участок». [AUTOTRANSLATED]</column>
@@ -874,7 +874,7 @@ The speech concludes with the words (in Federation Standard): "We come in peace.
       <column name="antonyms"></column>
       <column name="see_also">{tlhIngan maH!:sen}</column>
       <column name="notes">This literally means "We are Klingon, may it continue". The English subtitles render this as "Remain Klingon!"</column>
-      <column name="notes_de">Dies bedeutet wörtlich "Wir sind Klingonen, möge es weitergehen". Die englischen Untertitel geben dies als "Remain Klingon!" [AUTOTRANSLATED]</column>
+      <column name="notes_de">Dies bedeutet wörtlich "Wir sind Klingonen, möge es weitergehen". Die englischen Untertitel geben dies als "Klingonen bleiben!"</column>
       <column name="notes_fa">این به معنای واقعی کلمه به معنای "ما کلینگون هستیم ، ممکن است ادامه یابد" باشد. زیرنویس های انگلیسی این جمله را "Remain Klingon!" [AUTOTRANSLATED]</column>
       <column name="notes_sv">Detta betyder bokstavligen "Vi är Klingon, får det fortsätta". De engelska undertexterna återger detta som "Remain Klingon!" [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это буквально означает «мы клингон, пусть так и будет». Английские субтитры отображают это как «Remain Klingon!» [AUTOTRANSLATED]</column>
@@ -986,7 +986,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="antonyms"></column>
       <column name="see_also">{'aqaDyan Hol:n}</column>
       <column name="notes">This was the name of an ancient city on Earth, the capital of the Akkadian Empire.</column>
-      <column name="notes_de">Dies war der Name einer antiken Stadt auf der Erde, der Hauptstadt des akkadischen Reiches. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Dies war der Name einer antiken Stadt auf der Erde, der Hauptstadt des akkadischen Reiches.</column>
       <column name="notes_fa">این نام یک شهر باستانی روی زمین ، پایتخت امپراتوری اکدیان بود. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Detta var namnet på en gammal stad på jorden, huvudstaden i det Akkadiska riket. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это было название древнего города на земле, столицы Аккадской империи. [AUTOTRANSLATED]</column>
@@ -1064,7 +1064,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="antonyms"></column>
       <column name="see_also"></column>
       <column name="notes">She is the actress who plays {lurSa':n:name}.</column>
-      <column name="notes_de">Sie ist die Schauspielerin, die {lurSa':n:name} spielt. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Dies ist die Schauspielerin, die {lurSa':n:name} spielt.</column>
       <column name="notes_fa">او بازیگری است که {lurSa':n:name} بازی می کند. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Hon är skådespelerskan som spelar {lurSa':n:name}. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Актриса, которая играет {lurSa':n:name}.</column>
@@ -1181,7 +1181,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="antonyms"></column>
       <column name="see_also"></column>
       <column name="notes">This is what Klingons would call the Terran fruit.</column>
-      <column name="notes_de">So würden Klingonen die terranische Frucht nennen. [AUTOTRANSLATED]</column>
+      <column name="notes_de">So würden Klingonen die terranische Frucht nennen.</column>
       <column name="notes_fa">این چیزی است که کلینگون ها آن را تران می نامند. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Detta är vad Klingons skulle kalla Terranfrukten. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это то, что клингоны назвали бы фруктами терранов. [AUTOTRANSLATED]</column>
@@ -1337,7 +1337,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="antonyms"></column>
       <column name="see_also"></column>
       <column name="notes">This is the capital city of {DoyIchlan:n}.</column>
-      <column name="notes_de">Dies ist die Hauptstadt von {DoyIchlan:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Dies ist die Hauptstadt von {DoyIchlan:n}.</column>
       <column name="notes_fa">این شهر پایتخت {DoyIchlan:n} است. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Detta är huvudstaden i {DoyIchlan:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это столица {DoyIchlan:n}. [AUTOTRANSLATED]</column>
@@ -1561,7 +1561,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="entry_name">Da'lar</column>
       <column name="part_of_speech">n</column>
       <column name="definition">dollar</column>
-      <column name="definition_de">Dollar [AUTOTRANSLATED]</column>
+      <column name="definition_de">Dollar</column>
       <column name="definition_fa">دلار [AUTOTRANSLATED]</column>
       <column name="definition_sv">dollar [AUTOTRANSLATED]</column>
       <column name="definition_ru">доллар [AUTOTRANSLATED]</column>
@@ -2341,7 +2341,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="entry_name">lI'lIy</column>
       <column name="part_of_speech">n</column>
       <column name="definition">lily</column>
-      <column name="definition_de">Lilie [AUTOTRANSLATED]</column>
+      <column name="definition_de">Lilie</column>
       <column name="definition_fa">زنبق [AUTOTRANSLATED]</column>
       <column name="definition_sv">lilja [AUTOTRANSLATED]</column>
       <column name="definition_ru">Лили [AUTOTRANSLATED]</column>
@@ -2351,7 +2351,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="antonyms"></column>
       <column name="see_also"></column>
       <column name="notes">This is just borrowed in from Federation Standard. There is no native Klingon equivalent.</column>
-      <column name="notes_de">Dies ist nur von Federation Standard ausgeliehen. Es gibt kein einheimisches klingonisches Äquivalent. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Dies ist nur von Federation Standard ausgeliehen. Es gibt kein einheimisches klingonisches Äquivalent.</column>
       <column name="notes_fa">این فقط از فدراسیون استاندارد وام گرفته شده است. معادل کلینگون بومی وجود ندارد. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Detta är bara lånat från Federation Standard. Det finns ingen inhemsk Klingon-motsvarighet. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это просто заимствовано из Федерального стандарта. Нет родного клингонского эквивалента. [AUTOTRANSLATED]</column>
@@ -2585,7 +2585,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="antonyms"></column>
       <column name="see_also"></column>
       <column name="notes">This is the capital city of {raSya':n}.</column>
-      <column name="notes_de">Dies ist die Hauptstadt von {raSya':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Dies ist die Hauptstadt von {raSya':n}.</column>
       <column name="notes_fa">این شهر پایتخت {raSya':n} است. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Detta är huvudstaden i {raSya':n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это столица {raSya':n}. [AUTOTRANSLATED]</column>
@@ -2624,7 +2624,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="antonyms"></column>
       <column name="see_also"></column>
       <column name="notes">This is the name of a person from Earth history.</column>
-      <column name="notes_de">Dies ist der Name einer Person aus der Erdgeschichte. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Dies ist der Name einer Person aus der Erdgeschichte.</column>
       <column name="notes_fa">این نام شخصی از تاریخ زمین است. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Detta är namnet på en person från jordhistorien. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это имя человека из истории Земли. [AUTOTRANSLATED]</column>
@@ -2663,7 +2663,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="antonyms"></column>
       <column name="see_also"></column>
       <column name="notes">The actor who plays Worf ({wo'rIv:n:name}).</column>
-      <column name="notes_de">Der Schauspieler, der Worf spielt ({wo'rIv:n:name}). [AUTOTRANSLATED]</column>
+      <column name="notes_de">Der Schauspieler, der Worf spielt ({wo'rIv:n:name}).</column>
       <column name="notes_fa">بازیگری که ورف ({wo'rIv:n:name}) را بازی می کند. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Skådespelaren som spelar Worf ({wo'rIv:n:name}). [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это актёр, который играет Ворфа ({wo'rIv:n:name}).</column>
@@ -2702,7 +2702,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="antonyms"></column>
       <column name="see_also"></column>
       <column name="notes">The actor who played Kang ({qeng:n:name}).</column>
-      <column name="notes_de">Der Schauspieler, der Kang ({qeng:n:name}) spielte. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Der Schauspieler, der Kang ({qeng:n:name}) spielte.</column>
       <column name="notes_fa">بازیگر بازیگر کانگ ({qeng:n:name}). [AUTOTRANSLATED]</column>
       <column name="notes_sv">Skådespelaren som spelade Kang ({qeng:n:name}). [AUTOTRANSLATED]</column>
       <column name="notes_ru">Актёр, который играет Канга ({qeng:n:name}).</column>
@@ -2741,7 +2741,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="antonyms"></column>
       <column name="see_also"></column>
       <column name="notes">This is what a Klingon would call the Terran fruit.</column>
-      <column name="notes_de">So würde ein Klingone die terranische Frucht nennen. [AUTOTRANSLATED]</column>
+      <column name="notes_de">So würde ein Klingone die terranische Frucht nennen.</column>
       <column name="notes_fa">این چیزی است که یک کلینگون آن را ترران می نامد. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Detta är vad en Klingon skulle kalla Terranfrukten. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это то, что Клингон назовет земным фруктом</column>
@@ -2819,7 +2819,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="antonyms"></column>
       <column name="see_also"></column>
       <column name="notes">This is the name of a country on Earth.</column>
-      <column name="notes_de">Dies ist der Name eines Landes auf der Erde. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Dies ist der Name eines Landes auf der Erde.</column>
       <column name="notes_fa">این نام یک کشور روی کره زمین است. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Detta är namnet på ett land på jorden. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это название страны на Земле. [AUTOTRANSLATED]</column>
@@ -2965,7 +2965,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="entry_name">nIve'Da'</column>
       <column name="part_of_speech">n:place</column>
       <column name="definition">Nevada</column>
-      <column name="definition_de">Nevada [AUTOTRANSLATED]</column>
+      <column name="definition_de">Nevada</column>
       <column name="definition_fa">نوادا [AUTOTRANSLATED]</column>
       <column name="definition_sv">Nevada [AUTOTRANSLATED]</column>
       <column name="definition_ru">Невада [AUTOTRANSLATED]</column>
@@ -3092,7 +3092,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="antonyms"></column>
       <column name="see_also"></column>
       <column name="notes">This is the capital city of {vIraS:n}.</column>
-      <column name="notes_de">Dies ist die Hauptstadt von {vIraS:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Dies ist die Hauptstadt von {vIraS:n}.</column>
       <column name="notes_fa">این شهر پایتخت {vIraS:n} است. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Detta är huvudstaden i {vIraS:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это столица {vIraS:n}. [AUTOTRANSLATED]</column>
@@ -3160,7 +3160,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="entry_name">penSIlvenya'</column>
       <column name="part_of_speech">n:place</column>
       <column name="definition">Pennsylvania</column>
-      <column name="definition_de">Pennsylvania [AUTOTRANSLATED]</column>
+      <column name="definition_de">Pennsylvania</column>
       <column name="definition_fa">پنسیلوانیا [AUTOTRANSLATED]</column>
       <column name="definition_sv">Pennsylvania [AUTOTRANSLATED]</column>
       <column name="definition_ru">Пенсильвания [AUTOTRANSLATED]</column>
@@ -3287,7 +3287,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="antonyms"></column>
       <column name="see_also"></column>
       <column name="notes">This is what Klingons would call the Terran fruit.</column>
-      <column name="notes_de">So würden Klingonen die terranische Frucht nennen. [AUTOTRANSLATED]</column>
+      <column name="notes_de">So würden Klingonen die terranische Frucht nennen.</column>
       <column name="notes_fa">این چیزی است که کلینگون ها آن را تران می نامند. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Detta är vad Klingons skulle kalla Terranfrukten. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это то, что Клингоны зовут земным фруктом.</column>
@@ -3995,7 +3995,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="antonyms"></column>
       <column name="see_also"></column>
       <column name="notes">This is what Klingons would call the Terran fruit.</column>
-      <column name="notes_de">So würden Klingonen die terranische Frucht nennen. [AUTOTRANSLATED]</column>
+      <column name="notes_de">So würden Klingonen die terranische Frucht nennen.</column>
       <column name="notes_fa">این چیزی است که کلینگون ها آن را تران می نامند. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Detta är vad Klingons skulle kalla Terranfrukten. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это то, что Клингоны называют земным фруктом</column>
@@ -4180,7 +4180,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="entry_name">Sarbruqen</column>
       <column name="part_of_speech">n:place</column>
       <column name="definition">Saarbrücken (Germany)</column>
-      <column name="definition_de">Saarbrücken (Deutschland) [AUTOTRANSLATED]</column>
+      <column name="definition_de">Saarbrücken</column>
       <column name="definition_fa">ساربروکن (آلمان) [AUTOTRANSLATED]</column>
       <column name="definition_sv">Saarbrücken (Tyskland) [AUTOTRANSLATED]</column>
       <column name="definition_ru">Саарбрюккен (Германия) [AUTOTRANSLATED]</column>
@@ -4190,7 +4190,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="antonyms"></column>
       <column name="see_also"></column>
       <column name="notes">This is a city in {DoyIchlan:n} where the {qepHom'a':n} takes place.</column>
-      <column name="notes_de"></column>
+      <column name="notes_de">Stadt in {DoyIchlan:n}, Heimat des {qepHom'a':n}.</column>
       <column name="notes_fa"></column>
       <column name="notes_sv"></column>
       <column name="notes_ru"></column>
@@ -4474,7 +4474,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="antonyms"></column>
       <column name="see_also"></column>
       <column name="notes">This is what Klingons would call the Terran fruit.</column>
-      <column name="notes_de">So würden Klingonen die terranische Frucht nennen. [AUTOTRANSLATED]</column>
+      <column name="notes_de">So würden Klingonen die terranische Frucht nennen.</column>
       <column name="notes_fa">این چیزی است که کلینگون ها آن را تران می نامند. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Detta är vad Klingons skulle kalla Terranfrukten. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это то, что клингоны назвали бы фруктами терранов. [AUTOTRANSLATED]</column>
@@ -6102,7 +6102,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="entry_name">'InDIye'na'</column>
       <column name="part_of_speech">n:place</column>
       <column name="definition">Indiana</column>
-      <column name="definition_de">Indiana [AUTOTRANSLATED]</column>
+      <column name="definition_de">Indiana</column>
       <column name="definition_fa">ایندیانا [AUTOTRANSLATED]</column>
       <column name="definition_sv">Indiana [AUTOTRANSLATED]</column>
       <column name="definition_ru">Индиана [AUTOTRANSLATED]</column>


### PR DESCRIPTION
fix autotranslated German entries for qep'a' 27 words, plus some others I noticed while editing.