### PR TITLE
fix new words in German letter Q

### DIFF
--- a/mem-13-Q.xml
+++ b/mem-13-Q.xml
@@ -1113,7 +1113,7 @@ Watch a lesson on this word: {YouTube video:url:http://youtu.be/auqS6FR_RDE}</co
       <column name="entry_name">QaplaStep</column>
       <column name="part_of_speech">n</column>
       <column name="definition">spool, reel, spindle</column>
-      <column name="definition_de">Spule, Rolle, Spindel [AUTOTRANSLATED]</column>
+      <column name="definition_de">Spule, Rolle, Spindel</column>
       <column name="definition_fa">قرقره ، قرقره ، دوک نخ ریسی [AUTOTRANSLATED]</column>
       <column name="definition_sv">spole, rulle, spindel [AUTOTRANSLATED]</column>
       <column name="definition_ru">шпуля, катушка, шпиндель [AUTOTRANSLATED]</column>
@@ -1123,7 +1123,7 @@ Watch a lesson on this word: {YouTube video:url:http://youtu.be/auqS6FR_RDE}</co
       <column name="antonyms"></column>
       <column name="see_also">{jIrmoH:v:2}</column>
       <column name="notes">This refers to a device around which thread or wire is wound.</column>
-      <column name="notes_de">Dies bezieht sich auf eine Vorrichtung, um die ein Faden oder Draht gewickelt ist. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Dies bezieht sich auf eine Vorrichtung, um die ein Faden oder Draht gewickelt ist.</column>
       <column name="notes_fa">این به دستگاهی اطلاق می شود که نخ یا سیم در آن پیچیده شود. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Detta avser en anordning runt vilken tråd eller tråd är lindad. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это относится к устройству, вокруг которого наматывается нить или провод. [AUTOTRANSLATED]</column>
@@ -2660,7 +2660,7 @@ This word was awarded to {janSIy:n:name,nolink} as a Friend of Maltz.</column>
       <column name="entry_name">Qep</column>
       <column name="part_of_speech">v:is</column>
       <column name="definition">be anxious (about)</column>
-      <column name="definition_de">ängstlich sein [AUTOTRANSLATED]</column>
+      <column name="definition_de">besorgt sein sein</column>
       <column name="definition_fa">مضطرب باشید (درباره) [AUTOTRANSLATED]</column>
       <column name="definition_sv">vara orolig (ungefär) [AUTOTRANSLATED]</column>
       <column name="definition_ru">беспокоиться (о) [AUTOTRANSLATED]</column>
@@ -2670,7 +2670,7 @@ This word was awarded to {janSIy:n:name,nolink} as a Friend of Maltz.</column>
       <column name="antonyms"></column>
       <column name="see_also">{rejmorgh:n}, {bIt:v}</column>
       <column name="notes">The object, if there is one, is the thing that the subject is anxious about.</column>
-      <column name="notes_de">Das Objekt, falls es eines gibt, ist das, worüber sich das Subjekt Sorgen macht. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Das Objekt, falls es eins gibt, ist das, worüber sich das Subjekt Sorgen macht.</column>
       <column name="notes_fa">اگر موضوع وجود داشته باشد ، موضوعی است که موضوع از آن مضطرب است. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Objektet, om det finns ett, är det som ämnet är orolig för. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Объект, если таковой имеется, - это то, о чем беспокоится субъект. [AUTOTRANSLATED]</column>
@@ -2978,7 +2978,7 @@ Do not confuse with {qeq:v}.</column>
       <column name="entry_name">Qey'</column>
       <column name="part_of_speech">v:is</column>
       <column name="definition">be cool (temperature)</column>
-      <column name="definition_de">sei kühl (Temperatur) [AUTOTRANSLATED]</column>
+      <column name="definition_de">kühl sein</column>
       <column name="definition_fa">خنک باشد (دما) [AUTOTRANSLATED]</column>
       <column name="definition_sv">var sval (temperatur) [AUTOTRANSLATED]</column>
       <column name="definition_ru">быть прохладным (температура) [AUTOTRANSLATED]</column>
@@ -3405,7 +3405,7 @@ The names of the Klingon consonants consist of the sound followed by {ay:sen:nol
       <column name="entry_name">QIch wab Sar</column>
       <column name="part_of_speech">n:deriv</column>
       <column name="definition">allophone</column>
-      <column name="definition_de">Allophon [AUTOTRANSLATED]</column>
+      <column name="definition_de">Allophon</column>
       <column name="definition_fa">آلوفون [AUTOTRANSLATED]</column>
       <column name="definition_sv">allofon [AUTOTRANSLATED]</column>
       <column name="definition_ru">аллофон [AUTOTRANSLATED]</column>
@@ -4232,7 +4232,7 @@ This word was awarded to {janSIy:n:name,nolink} as a Friend of Maltz.</column>
       <column name="entry_name">QIS</column>
       <column name="part_of_speech">v:t_c</column>
       <column name="definition">stitch</column>
-      <column name="definition_de">Stich [AUTOTRANSLATED]</column>
+      <column name="definition_de">nähen</column>
       <column name="definition_fa">کوک [AUTOTRANSLATED]</column>
       <column name="definition_sv">sy [AUTOTRANSLATED]</column>
       <column name="definition_ru">стежок [AUTOTRANSLATED]</column>
@@ -4242,7 +4242,7 @@ This word was awarded to {janSIy:n:name,nolink} as a Friend of Maltz.</column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
       <column name="notes">The object is the thing being sewn or stitched together.</column>
-      <column name="notes_de">Das Objekt ist das Ding, das zusammengenäht oder zusammengenäht wird. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Das Objekt ist das Ding, das zusammengenäht wird.</column>
       <column name="notes_fa">جسم چیزی است که به هم دوخته یا بخیه می شود. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Objektet är det som sys eller sys samman. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Объект - это вещь, сшитая или сшитая вместе. [AUTOTRANSLATED]</column>
@@ -4782,7 +4782,7 @@ There is no traditional Klingon way to say something like "Merry Christmas". An 
       <column name="entry_name">Qo</column>
       <column name="part_of_speech">n</column>
       <column name="definition">tendency, propensity</column>
-      <column name="definition_de">Tendenz, Neigung [AUTOTRANSLATED]</column>
+      <column name="definition_de">Tendenz, Neigung</column>
       <column name="definition_fa">گرایش ، گرایش [AUTOTRANSLATED]</column>
       <column name="definition_sv">tendens, benägenhet [AUTOTRANSLATED]</column>
       <column name="definition_ru">тенденция, склонность [AUTOTRANSLATED]</column>
@@ -4792,7 +4792,7 @@ There is no traditional Klingon way to say something like "Merry Christmas". An 
       <column name="antonyms"></column>
       <column name="see_also"></column>
       <column name="notes">The suffix {-meH:v} and the verb {chIw:v} are used with this to express having a tendency to do something.</column>
-      <column name="notes_de">Das Suffix {-meH:v} und das Verb {chIw:v} werden damit verwendet, um die Tendenz auszudrücken, etwas zu tun. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Das Suffix {-meH:v} und das Verb {chIw:v} werden damit verwendet, um die Tendenz auszudrücken, etwas zu tun.</column>
       <column name="notes_fa">پسوند {-meH:v} و فعل {chIw:v} با این کار برای بیان تمایل به انجام کاری استفاده می شوند. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Suffixet {-meH:v} och verbet {chIw:v} används med detta för att uttrycka en tendens att göra något. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Суффикс {-meH:v} и глагол {chIw:v} используются вместе с этим, чтобы выразить склонность что-либо делать. [AUTOTRANSLATED]</column>
@@ -5194,7 +5194,7 @@ Agreement is also expressed by the idiomatic expression {wa' DoS wIqIp.:sen:idio
       <column name="entry_name">QoH</column>
       <column name="part_of_speech">v:t</column>
       <column name="definition">tap</column>
-      <column name="definition_de">Zapfhahn [AUTOTRANSLATED]</column>
+      <column name="definition_de">tippen, antippen</column>
       <column name="definition_fa">ضربه زدن [AUTOTRANSLATED]</column>
       <column name="definition_sv">knacka [AUTOTRANSLATED]</column>
       <column name="definition_ru">нажмите [AUTOTRANSLATED]</column>
@@ -5204,7 +5204,7 @@ Agreement is also expressed by the idiomatic expression {wa' DoS wIqIp.:sen:idio
       <column name="antonyms"></column>
       <column name="see_also"></column>
       <column name="notes">This means to touch one's fingers gently on something, usually a few times.</column>
-      <column name="notes_de"></column>
+      <column name="notes_de">Dies bedeutet mit dem Finger zart auf etwas zu tippen, meist mehrfach.</column>
       <column name="notes_fa"></column>
       <column name="notes_sv"></column>
       <column name="notes_ru"></column>


### PR DESCRIPTION
fix autotranslated German entries for qep'a' 27 words, plus some others I noticed while editing.