### PR TITLE
fix new words in German letter S

### DIFF
--- a/mem-15-S.xml
+++ b/mem-15-S.xml
@@ -2452,7 +2452,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
       <column name="entry_name">SeHjan</column>
       <column name="part_of_speech">n</column>
       <column name="definition">control-device, controlling-device</column>
-      <column name="definition_de">Steuergerät, Steuergerät [AUTOTRANSLATED]</column>
+      <column name="definition_de">Steuergerät, Kontrollgerät</column>
       <column name="definition_fa">دستگاه کنترل ، دستگاه کنترل [AUTOTRANSLATED]</column>
       <column name="definition_sv">styrenhet, styrenhet [AUTOTRANSLATED]</column>
       <column name="definition_ru">устройство управления, устройство управления [AUTOTRANSLATED]</column>
@@ -2462,7 +2462,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
       <column name="antonyms"></column>
       <column name="see_also"></column>
       <column name="notes">Usage of this outside of set, accepted expressions such as {bIQ SeHjan:n} is considered odd.</column>
-      <column name="notes_de">Die Verwendung dieser außerhalb des Satzes akzeptierten Ausdrücke wie {bIQ SeHjan:n} wird als ungerade angesehen. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Die Verwendung dieses Begriffes außerhalb von anerkannten Ausdrücken wie {bIQ SeHjan:n} wird als ungewöhnlich angesehen.</column>
       <column name="notes_fa">استفاده از این موارد خارج از مجموعه ، عبارات پذیرفته شده مانند {bIQ SeHjan:n} امری عجیب محسوب می شود. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Användning av detta utanför uppsatta, accepterade uttryck som {bIQ SeHjan:n} betraktas som udda. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Использование этого вне набора принятых выражений, таких как {bIQ SeHjan:n}, считается нечетным. [AUTOTRANSLATED]</column>
@@ -4366,7 +4366,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="entry_name">SImroD</column>
       <column name="part_of_speech">n</column>
       <column name="definition">power (physics)</column>
-      <column name="definition_de">Macht (Physik) [AUTOTRANSLATED]</column>
+      <column name="definition_de">Leistung (Physik)</column>
       <column name="definition_fa">قدرت (فیزیک) [AUTOTRANSLATED]</column>
       <column name="definition_sv">kraft (fysik) [AUTOTRANSLATED]</column>
       <column name="definition_ru">сила (физика) [AUTOTRANSLATED]</column>
@@ -4376,7 +4376,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="antonyms"></column>
       <column name="see_also"></column>
       <column name="notes">This is the amount of energy transferred or converted per unit time.</column>
-      <column name="notes_de">Dies ist die Menge an Energie, die pro Zeiteinheit übertragen oder umgewandelt wird. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Dies ist die Menge an Energie, die pro Zeiteinheit umgesetzt wird.</column>
       <column name="notes_fa">این مقدار انرژی منتقل شده یا تبدیل شده در واحد زمان است. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Detta är mängden energi som överförs eller konverteras per tidsenhet. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это количество энергии, переданной или преобразованной за единицу времени. [AUTOTRANSLATED]</column>
@@ -4457,7 +4457,7 @@ Some reference temperatures for the {SImyon:sen:nolink} scale (left) vs. Celsius
       <column name="entry_name">SInan</column>
       <column name="part_of_speech">n</column>
       <column name="definition">compass</column>
-      <column name="definition_de">Kompass [AUTOTRANSLATED]</column>
+      <column name="definition_de">Kompass</column>
       <column name="definition_fa">قطب نما [AUTOTRANSLATED]</column>
       <column name="definition_sv">kompass [AUTOTRANSLATED]</column>
       <column name="definition_ru">компас [AUTOTRANSLATED]</column>
@@ -4467,7 +4467,7 @@ Some reference temperatures for the {SImyon:sen:nolink} scale (left) vs. Celsius
       <column name="antonyms"></column>
       <column name="see_also">{lurgh:n}, {peQnagh:n}, {chan:n}, {tIng:n}, {'ev:v}</column>
       <column name="notes">This refers to the geographic tool, not the drawing tool.</column>
-      <column name="notes_de">Dies bezieht sich auf das geografische Werkzeug, nicht auf das Zeichenwerkzeug. [AUTOTRANSLATED]</column>
+      <column name="notes_de"></column>
       <column name="notes_fa">این به ابزار جغرافیایی و نه ابزار ترسیم اشاره دارد. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Detta hänvisar till det geografiska verktyget, inte till ritverktyget. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это относится к географическому инструменту, а не к инструменту рисования. [AUTOTRANSLATED]</column>
@@ -7821,7 +7821,7 @@ This verb is also used for the encryption of data.[3]</column>
       <column name="entry_name">So'chIm</column>
       <column name="part_of_speech">n:being</column>
       <column name="definition">soh-chim</column>
-      <column name="definition_de">Soh-Chim [AUTOTRANSLATED]</column>
+      <column name="definition_de">Soh-Chim</column>
       <column name="definition_fa">سوهیم [AUTOTRANSLATED]</column>
       <column name="definition_sv">soh-chim [AUTOTRANSLATED]</column>
       <column name="definition_ru">SOH-Хим [AUTOTRANSLATED]</column>
@@ -8659,7 +8659,7 @@ The expression {jISum:sen:nolink} has an idiomatic philosophical meaning, "I'm i
       <column name="entry_name">SupDIng</column>
       <column name="part_of_speech">n</column>
       <column name="definition">cotton-like plant</column>
-      <column name="definition_de">baumwollähnliche Pflanze [AUTOTRANSLATED]</column>
+      <column name="definition_de">baumwollähnliche Pflanze</column>
       <column name="definition_fa">گیاه مانند پنبه [AUTOTRANSLATED]</column>
       <column name="definition_sv">bomullsliknande växt [AUTOTRANSLATED]</column>
       <column name="definition_ru">хлопкоподобное растение [AUTOTRANSLATED]</column>
@@ -8669,7 +8669,7 @@ The expression {jISum:sen:nolink} has an idiomatic philosophical meaning, "I'm i
       <column name="antonyms"></column>
       <column name="see_also"></column>
       <column name="notes">This is a Klingon plant, parts of which are used to make cloth.</column>
-      <column name="notes_de">Dies ist eine klingonische Pflanze, aus deren Teilen Stoffe hergestellt werden. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Dies ist eine klingonische Pflanze, aus deren Teilen Stoffe hergestellt werden.</column>
       <column name="notes_fa">این گیاه کلینگون است که قسمت هایی از آن برای ساخت پارچه استفاده می شود. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Det här är en Klingon-anläggning, vars delar används för att göra tyg. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это клингонское растение, части которого используются для изготовления ткани. [AUTOTRANSLATED]</column>
@@ -9760,7 +9760,7 @@ This can also be used for blowing out a candle ({weQ:n}). Unlike with {jo':v}, a
       <column name="entry_name">SuyDar</column>
       <column name="part_of_speech">n</column>
       <column name="definition">qubit (quantum bit)</column>
-      <column name="definition_de">Qubit (Quantenbit) [AUTOTRANSLATED]</column>
+      <column name="definition_de">Qubit (Quantenbit)</column>
       <column name="definition_fa">qubit (بیت کوانتومی) [AUTOTRANSLATED]</column>
       <column name="definition_sv">kvbit (kvantbit) [AUTOTRANSLATED]</column>
       <column name="definition_ru">кубит (квантовый бит) [AUTOTRANSLATED]</column>
@@ -9770,7 +9770,7 @@ This can also be used for blowing out a candle ({weQ:n}). Unlike with {jo':v}, a
       <column name="antonyms"></column>
       <column name="see_also">{San'on:n}, {mergh:v}, {'otlhQeD:n}, {maySon:n}</column>
       <column name="notes">Sometimes {SuyDar San'on:n@@SuyDar:n, San'on:n} is also used.</column>
-      <column name="notes_de">Manchmal wird auch {SuyDar San'on:n@@SuyDar:n, San'on:n} verwendet. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Manchmal wird auch {SuyDar San'on:n@@SuyDar:n, San'on:n} verwendet.</column>
       <column name="notes_fa">گاهی اوقات از {SuyDar San'on:n@@SuyDar:n, San'on:n} نیز استفاده می شود. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Ibland används {SuyDar San'on:n@@SuyDar:n, San'on:n} också. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Иногда также используется {SuyDar San'on:n@@SuyDar:n, San'on:n}. [AUTOTRANSLATED]</column>


### PR DESCRIPTION
fix autotranslated German entries for qep'a' 27 words, plus some others I noticed while editing.