### PR TITLE
fix qut entry + other

### DIFF
--- a/mem-12-q.xml
+++ b/mem-12-q.xml
@@ -2397,7 +2397,7 @@ This word is applied to people and animals.[2]</column>
       <column name="antonyms"></column>
       <column name="see_also">{loS reD mey':n}</column>
       <column name="notes">This refers to a convex quadrilateral with at least one pair of parallel sides. A quadrilateral with no parallel sides is a {moHbey:n}.</column>
-      <column name="notes_de">Dies bezieht sich auf ein konvexes Viereck mit mindestens zwei parallelen Seiten. Ein Viereck ohne parallele Seiten ist ein {moHbey:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Dies bezieht sich auf ein konvexes Viereck mit mindestens zwei parallelen Seiten. Ein Viereck ohne parallele Seiten ist ein {moHbey:n}.</column>
       <column name="notes_fa">این اشاره به چهار ضلعی محدب با حداقل یک جفت طرف موازی دارد. چهار ضلعی با طرفین موازی {moHbey:n} نیست. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Detta avser en konvex fyrkantig med minst ett par parallella sidor. En fyrkantig utan parallella sidor är en {moHbey:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это относится к выпуклому четырехугольнику с по меньшей мере одной парой параллельных сторон. Четырехугольник без параллельных сторон является {moHbey:n}. [AUTOTRANSLATED]</column>
@@ -7737,7 +7737,7 @@ Maltz seemed reluctant to talk about what exactly this is.[2]</column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
       <column name="notes">This refers to a person, and isn't the word to use when referring to the other half of a pair of socks or gloves or the like, for which see {nelwI':n}.[2]</column>
-      <column name="notes_de">Dies bezieht sich auf eine Person und ist nicht das Wort, das verwendet werden soll, wenn auf die andere Hälfte eines Paares Socken oder Handschuhe oder dergleichen Bezug genommen wird, siehe {nelwI':n}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_de">Dies bezieht sich auf eine Person und ist nicht das Wort, das verwendet werden soll, wenn auf die andere Hälfte eines Paares Socken oder Handschuhe oder dergleichen Bezug genommen wird, siehe {nelwI':n}.[2]</column>
       <column name="notes_fa">این به شخص مربوط می شود و کلمه ای نیست که هنگام مراجعه به نیمه دیگر جفت جوراب یا دستکش یا موارد مشابه از آن استفاده کند ، که برای آن مراجعه کنید {nelwI':n}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_sv">Detta hänvisar till en person, och är inte ordet att använda när man hänvisar till den andra halvan av ett par strumpor eller handskar eller liknande, för vilka se {nelwI':n}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это относится к человеку, а не к слову, используемому при обращении к другой половине пары носков или перчаток или тому подобного, о которой см. {nelwI':n}.[2] [AUTOTRANSLATED]</column>
@@ -7776,7 +7776,7 @@ Maltz seemed reluctant to talk about what exactly this is.[2]</column>
       <column name="antonyms"></column>
       <column name="see_also">{ngaH:v}, {'olQan:n}</column>
       <column name="notes">The object of this verb is the space being squeezed into, such as a small car or crowded elevator, or clothes or shoes that are too small.</column>
-      <column name="notes_de">Das Objekt dieses Verbs ist der Raum, in den gepresst wird, z. B. ein kleines Auto oder ein überfüllter Aufzug oder Kleidung oder Schuhe, die zu klein sind. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Das Objekt dieses Verbs ist der Raum, in den man gepresst wird, z. B. ein kleines Auto oder ein überfüllter Aufzug oder Kleidung oder Schuhe, die zu klein sind.</column>
       <column name="notes_fa">هدف این فعل فضایی است که در آن فشرده می شود ، مانند یک ماشین کوچک یا آسانسور شلوغ ، یا لباس یا کفش خیلی کوچک. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Syftet med detta verb är utrymmet som pressas in i, till exempel en liten bil eller trångt hiss, eller kläder eller skor som är för små. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Объектом для данного глагола является пространство, в которое происходит втискивание, такое как маленькая машина или забитый людьми лифт, или одежда, или обувь, которые также малы.</column>
@@ -11682,7 +11682,7 @@ This word can't be used for a hole in the ground (for which see {QemjIq:n}), but
       <column name="entry_name">qut</column>
       <column name="part_of_speech">n</column>
       <column name="definition">crystal (geologic formation)</column>
-      <column name="definition_de">Kristall</column>
+      <column name="definition_de">Kristall (geologische Struktur)</column>
       <column name="definition_fa">کریستال (تشکیل ژئولوژیک) [AUTOTRANSLATED]</column>
       <column name="definition_sv">kristall (geologisk formation)</column>
       <column name="definition_ru">кристалл (геологическое формирование)</column>
@@ -11731,7 +11731,7 @@ This word can't be used for a hole in the ground (for which see {QemjIq:n}), but
       <column name="antonyms"></column>
       <column name="see_also"></column>
       <column name="notes">This is also sometimes {Do'ol na':n@@Do'ol:n, na':v:1}, presumably depending on the exact form of the substance.</column>
-      <column name="notes_de">Dies ist manchmal auch {Do'ol na':n@@Do'ol:n, na':v:1}, vermutlich abhängig von der genauen Form der Substanz. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Dies ist manchmal auch {Do'ol na':n@@Do'ol:n, na':v:1}, vermutlich abhängig von der genauen Form der Substanz.</column>
       <column name="notes_fa">این نیز گاهی اوقات {Do'ol na':n@@Do'ol:n, na':v:1} است ، احتمالاً بسته به شکل دقیق ماده. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Detta är också ibland {Do'ol na':n@@Do'ol:n, na':v:1}, förmodligen beroende på ämnets exakta form. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это также иногда {Do'ol na':n@@Do'ol:n, na':v:1}, по-видимому, в зависимости от точной формы вещества. [AUTOTRANSLATED]</column>


### PR DESCRIPTION
changed qut translation to mark as geological formation. Kristall can refer to glass as well, which is technically not a crystal formation.