### PR TITLE
fix new words in German letter t

### DIFF
--- a/mem-16-t.xml
+++ b/mem-16-t.xml
@@ -1681,7 +1681,7 @@ The English translation of the sentence from {Star Trek Constellations:src} does
       <column name="entry_name">tapqej</column>
       <column name="part_of_speech">n:food</column>
       <column name="definition">cherry</column>
-      <column name="definition_de">Kirsche [AUTOTRANSLATED]</column>
+      <column name="definition_de">Kirsche</column>
       <column name="definition_fa">گیلاس [AUTOTRANSLATED]</column>
       <column name="definition_sv">körsbär [AUTOTRANSLATED]</column>
       <column name="definition_ru">вишня [AUTOTRANSLATED]</column>
@@ -1691,7 +1691,7 @@ The English translation of the sentence from {Star Trek Constellations:src} does
       <column name="antonyms"></column>
       <column name="see_also"></column>
       <column name="notes">This is a fruit similar to a cherry. When clarification is needed, for the Earth fruit, precede with {tera':n}.</column>
-      <column name="notes_de"></column>
+      <column name="notes_de">Dies ist eine Frucht, die der Kirsche ähnelt. Falls man unterscheiden muss, wird {tera':n} hinzugefügt.</column>
       <column name="notes_fa"></column>
       <column name="notes_sv"></column>
       <column name="notes_ru"></column>
@@ -3746,7 +3746,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="entry_name">telya'</column>
       <column name="part_of_speech">n:body</column>
       <column name="definition">pancreas</column>
-      <column name="definition_de">Pankreas [AUTOTRANSLATED]</column>
+      <column name="definition_de">Bauchspeicheldrüse, Pankreas</column>
       <column name="definition_fa">لوزالمعده [AUTOTRANSLATED]</column>
       <column name="definition_sv">bukspottkörteln [AUTOTRANSLATED]</column>
       <column name="definition_ru">поджелудочная железа [AUTOTRANSLATED]</column>
@@ -3834,7 +3834,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="antonyms">{chID:v}</column>
       <column name="see_also">{tlhoch:v}</column>
       <column name="notes">This means "contradict, disavow, claim as false" and the like. It does not mean "refuse, reject, turn down, don't permit".[2]</column>
-      <column name="notes_de">Dies bedeutet "widersprechen, ablehnen, als falsch behaupten" und dergleichen. Es bedeutet nicht "ablehnen, ablehnen, ablehnen, nicht zulassen".[2] [AUTOTRANSLATED]</column>
+      <column name="notes_de"></column>
       <column name="notes_fa">این به معنای "متناقض ، مخالفت ، ادعای دروغین" و موارد مشابه است. این به معنای "امتناع ، رد کردن ، رد کردن ، مجاز نبودن" نیست.[2] [AUTOTRANSLATED]</column>
       <column name="notes_sv">Detta betyder "motsäga, avvisa, hävda som falskt" och liknande. Det betyder inte "vägra, avslå, avslå, inte tillåta".[2] [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это означает «противоречить, дезавуировать, утверждать, что оно ложное» и тому подобное. Это не означает «отказывайся, отвергай, отказывайся, не разрешай».[2] [AUTOTRANSLATED]</column>
@@ -3850,7 +3850,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
       <column name="search_tags">contradict, disavow, claim as false</column>
-      <column name="search_tags_de"></column>
+      <column name="search_tags_de">widersprechen, ablehnen, als falsch behaupten</column>
       <column name="search_tags_fa"></column>
       <column name="search_tags_sv"></column>
       <column name="search_tags_ru"></column>
@@ -3951,7 +3951,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="antonyms"></column>
       <column name="see_also">{vav:n}, {'e'mam:n}</column>
       <column name="notes">The child of a {tennuS:n:nolink} is a {tey':n:1}.</column>
-      <column name="notes_de">Das Kind eines {tennuS:n:nolink} ist ein {tey':n:1}. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Das Kind eines {tennuS:n:nolink} ist ein {tey':n:1}.</column>
       <column name="notes_fa"></column>
       <column name="notes_sv"></column>
       <column name="notes_ru">Дитя {tennuS:n:nolink} - это {tey':n:1}. [AUTOTRANSLATED]</column>
@@ -4029,7 +4029,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="antonyms"></column>
       <column name="see_also">{nav:n}</column>
       <column name="notes">This is used only for numbered pages in a book or something similar.</column>
-      <column name="notes_de">Dies wird nur für nummerierte Seiten in einem Buch oder ähnlichem verwendet. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Dies wird nur für nummerierte Seiten in einem Buch oder ähnlichem verwendet.</column>
       <column name="notes_fa">این فقط برای صفحات شماره گذاری شده در یک کتاب یا چیز مشابه استفاده می شود. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Detta används endast för numrerade sidor i en bok eller något liknande. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это используется только для пронумерованных страниц в книге или что-то подобное. [AUTOTRANSLATED]</column>
@@ -4186,7 +4186,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="antonyms"></column>
       <column name="see_also"></column>
       <column name="notes">In the {BoP:src} poster, this is a type of crane.</column>
-      <column name="notes_de">Im {BoP:src}-Poster ist dies eine Art Kran. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Im {BoP:src}-Poster ist dies eine Art Kran.</column>
       <column name="notes_fa">در پوستر {BoP:src} ، این نوع جرثقیل است. [AUTOTRANSLATED]</column>
       <column name="notes_sv">På {BoP:src}-affischen är detta en typ av kran. [AUTOTRANSLATED]</column>
       <column name="notes_ru">На плакате {BoP:src} это тип крана. [AUTOTRANSLATED]</column>
@@ -4225,7 +4225,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="antonyms"></column>
       <column name="see_also">{tuQHa'moH:v}, {nge':v}, {jotlh:v}</column>
       <column name="notes">For the removal of something from the interior, consider {lel:v}.</column>
-      <column name="notes_de">Ziehen Sie {lel:v} in Betracht, um etwas aus dem Innenraum zu entfernen. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Um etwas aus einem Behälter zu nehmen, verwendet man eher das Verb {lel:v}.</column>
       <column name="notes_fa">برای خارج کردن چیزی از فضای داخلی ، {lel:v} را در نظر بگیرید. [AUTOTRANSLATED]</column>
       <column name="notes_sv">För att ta bort något från interiören, överväga {lel:v}. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Для удаления чего-то из интерьера, рассмотрите {lel:v}. [AUTOTRANSLATED]</column>
@@ -4383,7 +4383,7 @@ Note that a human ({Human:n}) is a member of the major indigenous language-capab
       <column name="entry_name">tera' ghIch rop</column>
       <column name="part_of_speech">n:deriv</column>
       <column name="definition">common cold</column>
-      <column name="definition_de">Erkältung [AUTOTRANSLATED]</column>
+      <column name="definition_de">Erkältung</column>
       <column name="definition_fa">سرماخوردگی [AUTOTRANSLATED]</column>
       <column name="definition_sv">förkylning [AUTOTRANSLATED]</column>
       <column name="definition_ru">простуда [AUTOTRANSLATED]</column>
@@ -4393,7 +4393,7 @@ Note that a human ({Human:n}) is a member of the major indigenous language-capab
       <column name="antonyms"></column>
       <column name="see_also"></column>
       <column name="notes">Maltz says Klingons don't get colds (though, despite what he says, Klingons are not immune from other, somewhat similar afflictions). Another way to refer to this Earth disease, generally unsympathetically, is {tera' rop bIr:n:nolink}, which is, of course, a misguided translation.</column>
-      <column name="notes_de">Maltz sagt, Klingonen bekommen keine Erkältungen (obwohl Klingonen trotz seiner Aussagen nicht immun gegen andere, etwas ähnliche Leiden sind). Eine andere Möglichkeit, sich auf diese Erdkrankheit zu beziehen, die im Allgemeinen unsympathisch ist, ist {tera' rop bIr:n:nolink}, was natürlich eine fehlgeleitete Übersetzung ist. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Maltz sagt, Klingonen bekommen keine Erkältung (obwohl Klingonen trotz seiner Aussagen nicht immun gegen andere ähnliche Leiden sind). Eine andere Möglichkeit, sich auf diese Erdkrankheit zu beziehen, die im Allgemeinen unsympathisch ist, ist {tera' rop bIr:n:nolink}, was natürlich eine fehlgeleitete Übersetzung ist.</column>
       <column name="notes_fa">مالتز می گوید کلینگونها دچار سرماخوردگی نمی شوند (گرچه ، علیرغم آنچه که او می گوید ، کلینگون ها از مصائب دیگر ، تا حدودی مشابه مصون نیستند). روش دیگر برای مراجعه به این بیماری زمین ، که عموماً به صورت غیر همدلی است ، {tera' rop bIr:n:nolink} است که البته این یک ترجمه اشتباه است. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Maltz säger att Klingons inte blir förkylda (trots att han säger, är Klingons inte immun mot andra, något liknande lidelser). Ett annat sätt att hänvisa till denna jordsjukdom, i allmänhet osympatisk, är {tera' rop bIr:n:nolink}, vilket naturligtvis är en felaktig översättning. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Мальц говорит, что клингоны не болеют простудой (хотя, несмотря на то, что он говорит, клингоны не застрахованы от других, несколько похожих болезней). Другим способом обозначения этой земной болезни, обычно не сочувствующим, является {tera' rop bIr:n:nolink}, что, конечно, является ошибочным переводом. [AUTOTRANSLATED]</column>
@@ -4677,7 +4677,7 @@ The Terran months are:
       <column name="entry_name">tera' tlhuH rop</column>
       <column name="part_of_speech">n:deriv</column>
       <column name="definition">common cold</column>
-      <column name="definition_de">Erkältung [AUTOTRANSLATED]</column>
+      <column name="definition_de">Erkältung</column>
       <column name="definition_fa">سرماخوردگی [AUTOTRANSLATED]</column>
       <column name="definition_sv">förkylning [AUTOTRANSLATED]</column>
       <column name="definition_ru">простуда [AUTOTRANSLATED]</column>
@@ -4687,7 +4687,7 @@ The Terran months are:
       <column name="antonyms"></column>
       <column name="see_also"></column>
       <column name="notes">Maltz says Klingons don't get colds (though, despite what he says, Klingons are not immune from other, somewhat similar afflictions). Another way to refer to this Earth disease, generally unsympathetically, is {tera' rop bIr:n:nolink}, which is, of course, a misguided translation.</column>
-      <column name="notes_de">Maltz sagt, Klingonen bekommen keine Erkältungen (obwohl Klingonen trotz seiner Aussagen nicht immun gegen andere, etwas ähnliche Leiden sind). Eine andere Möglichkeit, sich auf diese Erdkrankheit zu beziehen, die im Allgemeinen unsympathisch ist, ist {tera' rop bIr:n:nolink}, was natürlich eine fehlgeleitete Übersetzung ist. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Maltz sagt, Klingonen bekommen keine Erkältung (obwohl Klingonen trotz seiner Aussagen nicht immun gegen andere ähnliche Leiden sind). Eine andere Möglichkeit, sich auf diese Erdkrankheit zu beziehen, die im Allgemeinen unsympathisch ist, ist {tera' rop bIr:n:nolink}, was natürlich eine fehlgeleitete Übersetzung ist.</column>
       <column name="notes_fa">مالتز می گوید کلینگونها دچار سرماخوردگی نمی شوند (گرچه ، علیرغم آنچه که او می گوید ، کلینگون ها از مصائب دیگر ، تا حدودی مشابه مصون نیستند). روش دیگر برای مراجعه به این بیماری زمین ، که عموماً به صورت غیر همدلی است ، {tera' rop bIr:n:nolink} است که البته این یک ترجمه اشتباه است. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Maltz säger att Klingons inte blir förkylda (trots att han säger, är Klingons inte immun mot andra, något liknande lidelser). Ett annat sätt att hänvisa till denna jordsjukdom, i allmänhet osympatisk, är {tera' rop bIr:n:nolink}, vilket naturligtvis är en felaktig översättning. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Мальц говорит, что клингоны не болеют простудой (хотя, несмотря на то, что он говорит, клингоны не застрахованы от других, несколько похожих болезней). Другим способом обозначения этой земной болезни, обычно не сочувствующим, является {tera' rop bIr:n:nolink}, что, конечно, является ошибочным переводом. [AUTOTRANSLATED]</column>
@@ -4955,7 +4955,7 @@ The Terran months are:
       <column name="entry_name">tetyub</column>
       <column name="part_of_speech">n</column>
       <column name="definition">enamel, coating</column>
-      <column name="definition_de">Emaille, Beschichtung [AUTOTRANSLATED]</column>
+      <column name="definition_de">Emaille, Beschichtung</column>
       <column name="definition_fa">مینا ، پوشش [AUTOTRANSLATED]</column>
       <column name="definition_sv">emalj, beläggning [AUTOTRANSLATED]</column>
       <column name="definition_ru">эмаль, покрытие [AUTOTRANSLATED]</column>
@@ -4965,7 +4965,7 @@ The Terran months are:
       <column name="antonyms"></column>
       <column name="see_also">{vel:v}</column>
       <column name="notes">This refers to any sort of artificial coating, not just enamel. It does not apply to teeth.</column>
-      <column name="notes_de">Dies bezieht sich auf jede Art von künstlicher Beschichtung, nicht nur auf Email. Es gilt nicht für Zähne. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Dies bezieht sich auf jede Art von künstlicher Beschichtung, nicht nur auf Emaille. Es gilt nicht für Zähne.</column>
       <column name="notes_fa">این به هر نوع پوشش مصنوعی و نه فقط مینای دندان اشاره دارد. در مورد دندانها صدق نمی کند. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Detta avser alla typer av konstgjord beläggning, inte bara emalj. Det gäller inte tänder. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это относится к любому виду искусственного покрытия, а не только к эмали. Это не относится к зубам. [AUTOTRANSLATED]</column>
@@ -6933,7 +6933,7 @@ This verb can be used reflexively to mean "enjoy oneself", "have a good time".[3
       <column name="entry_name">tIy</column>
       <column name="part_of_speech">v:is</column>
       <column name="definition">be curly</column>
-      <column name="definition_de">sei lockig [AUTOTRANSLATED]</column>
+      <column name="definition_de">gelockt sein, lockig sein</column>
       <column name="definition_fa">فرفری باشد [AUTOTRANSLATED]</column>
       <column name="definition_sv">vara lockigt [AUTOTRANSLATED]</column>
       <column name="definition_ru">быть кудрявым [AUTOTRANSLATED]</column>
@@ -6982,7 +6982,7 @@ This verb can be used reflexively to mean "enjoy oneself", "have a good time".[3
       <column name="antonyms"></column>
       <column name="see_also"></column>
       <column name="notes">Unlike {rach:v}, this verb is not typically applied to beings, and it suggests only restoration to a previous state (and not necessarily improvement).[2]</column>
-      <column name="notes_de">Im Gegensatz zu {rach:v} wird dieses Verb normalerweise nicht auf Wesen angewendet und schlägt nur die Wiederherstellung eines früheren Zustands (und nicht unbedingt die Verbesserung) vor .[2] [AUTOTRANSLATED]</column>
+      <column name="notes_de">Im Gegensatz zu {rach:v} wird dieses Verb normalerweise nicht auf Wesen angewendet und schlägt nur die Wiederherstellung eines früheren Zustands (und nicht unbedingt die Verbesserung) vor .[2]</column>
       <column name="notes_fa"></column>
       <column name="notes_sv"></column>
       <column name="notes_ru">В отличие от {rach:v}, этот глагол, как правило, не применяется к существам и предлагает только восстановление предыдущего состояния (и не обязательно улучшение) .[2] [AUTOTRANSLATED]</column>
@@ -7099,7 +7099,7 @@ This verb can be used reflexively to mean "enjoy oneself", "have a good time".[3
       <column name="antonyms"></column>
       <column name="see_also">{vIghro':n}</column>
       <column name="notes">There is an idiom, {bIt; tI'qa' vIghro' rur@@bIt:v, tI'qa' vIghro':n, rur:v}.</column>
-      <column name="notes_de">Es gibt eine Redewendung, {bIt; tI'qa' vIghro' rur@@bIt:v, tI'qa' vIghro':n, rur:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Es gibt eine Redewendung: {bIt; tI'qa' vIghro' rur@@bIt:v, tI'qa' vIghro':n, rur:v}.</column>
       <column name="notes_fa">یک اصطلاح ، {bIt; tI'qa' vIghro' rur@@bIt:v, tI'qa' vIghro':n, rur:v} وجود دارد. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Det finns ett formspråk, {bIt; tI'qa' vIghro' rur@@bIt:v, tI'qa' vIghro':n, rur:v}. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Существует идиома {bIt; tI'qa' vIghro' rur@@bIt:v, tI'qa' vIghro':n, rur:v}. [AUTOTRANSLATED]</column>
@@ -7128,7 +7128,7 @@ This verb can be used reflexively to mean "enjoy oneself", "have a good time".[3
       <column name="entry_name">tI'rIl</column>
       <column name="part_of_speech">n:place,fic</column>
       <column name="definition">Trill (planet)</column>
-      <column name="definition_de">Trill (Planet) [AUTOTRANSLATED]</column>
+      <column name="definition_de">Trill (Planet)</column>
       <column name="definition_fa">تریل (سیاره) [AUTOTRANSLATED]</column>
       <column name="definition_sv">Trill (planet) [AUTOTRANSLATED]</column>
       <column name="definition_ru">Трель (планета) [AUTOTRANSLATED]</column>
@@ -7138,7 +7138,7 @@ This verb can be used reflexively to mean "enjoy oneself", "have a good time".[3
       <column name="antonyms"></column>
       <column name="see_also">{tI'rIlngan:n}, {boqyIn:n}</column>
       <column name="notes">This is the name of the planet.</column>
-      <column name="notes_de">Dies ist der Name des Planeten. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Dies ist der Name des Planeten.</column>
       <column name="notes_fa">این نام سیاره است. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Detta är planetens namn. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это название планеты. [AUTOTRANSLATED]</column>
@@ -7167,7 +7167,7 @@ This verb can be used reflexively to mean "enjoy oneself", "have a good time".[3
           <column name="entry_name">tI'rIlngan</column>
           <column name="part_of_speech">n:being,fic,deriv</column>
           <column name="definition">Trill (person)</column>
-          <column name="definition_de">Trill (Person) [AUTOTRANSLATED]</column>
+          <column name="definition_de">Trill (Person)</column>
           <column name="definition_fa">تریل (شخص) [AUTOTRANSLATED]</column>
           <column name="definition_sv">Trill (person) [AUTOTRANSLATED]</column>
           <column name="definition_ru">Трель (человек) [AUTOTRANSLATED]</column>
@@ -7216,7 +7216,7 @@ This verb can be used reflexively to mean "enjoy oneself", "have a good time".[3
       <column name="antonyms"></column>
       <column name="see_also"></column>
       <column name="notes">The son of Barot. See {barot:n}.</column>
-      <column name="notes_de">Der Sohn von Barot. Siehe {barot:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Sohn von {barot:n}.</column>
       <column name="notes_fa">پسر باروت. به {barot:n} مراجعه کنید. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Barot's son. Se {barot:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Сын Баро. Смотрите {barot:n}. [AUTOTRANSLATED]</column>
@@ -7491,7 +7491,7 @@ This verb can be used reflexively to mean "enjoy oneself", "have a good time".[3
       <column name="antonyms"></column>
       <column name="see_also"></column>
       <column name="notes">For courage of a surprising or unexpected kind, see {qajunpaQ:n}.</column>
-      <column name="notes_de">Für überraschenden oder unerwarteten Mut siehe {qajunpaQ:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Für überraschenden oder unerwarteten Mut siehe {qajunpaQ:n}.</column>
       <column name="notes_fa">برای شجاعت یک نوع تعجب آور یا غیر منتظره ، به {qajunpaQ:n} مراجعه کنید. [AUTOTRANSLATED]</column>
       <column name="notes_sv">För {qajunpaQ:n} för mod av överraskande eller oväntat slag. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Для смелости удивительного или неожиданного вида, см. {qajunpaQ:n}. [AUTOTRANSLATED]</column>
@@ -7609,7 +7609,7 @@ This verb can be used reflexively to mean "enjoy oneself", "have a good time".[3
       <column name="antonyms"></column>
       <column name="see_also"></column>
       <column name="notes">This is roughly like the English "Aha!" ({TKD 5.5:src})</column>
-      <column name="notes_de">Dies ist ungefähr wie das englische "Aha!" ({TKD 5.5:src}) [AUTOTRANSLATED]</column>
+      <column name="notes_de">Dies ist ungefähr wie das deutsche "Aha!" ({TKD 5.5:src})</column>
       <column name="notes_fa">این تقریباً شبیه انگلیسی "Aha!" ({TKD 5.5:src}) [AUTOTRANSLATED]</column>
       <column name="notes_sv">Detta är ungefär som det engelska "Aha!" ({TKD 5.5:src}) [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это примерно как английское "Ага!" ({TKD 5.5:src}) [AUTOTRANSLATED]</column>
@@ -7649,7 +7649,7 @@ This verb can be used reflexively to mean "enjoy oneself", "have a good time".[3
       <column name="antonyms"></column>
       <column name="see_also">{ngor:v}, {jech:v}, {ghet:v}, {HIgh:v}, {Qaq:v}, {nep:v}, {chem:v}, {ghIchwIj DabochmoHchugh ghIchlIj qanob.:sen}</column>
       <column name="notes">If the deception involves honor or social status, see {Qaq:v}.</column>
-      <column name="notes_de">Wenn die Täuschung Ehre oder sozialen Status beinhaltet, siehe {Qaq:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Wenn die Täuschung Ehre oder sozialen Status beinhaltet, siehe {Qaq:v}.</column>
       <column name="notes_fa">اگر فریب شامل افتخار یا وضعیت اجتماعی است ، به {Qaq:v} مراجعه کنید. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Om bedrägeriet innebär ära eller social status, se {Qaq:v}. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Если обман связан с честью или социальным статусом, см. {Qaq:v}. [AUTOTRANSLATED]</column>
@@ -7808,7 +7808,7 @@ This verb can be used reflexively to mean "enjoy oneself", "have a good time".[3
       <column name="antonyms"></column>
       <column name="see_also">{taH:v:2}</column>
       <column name="notes">This can be used for a head movement.</column>
-      <column name="notes_de">Dies kann für eine Kopfbewegung verwendet werden. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Dies kann für eine Kopfbewegung verwendet werden.</column>
       <column name="notes_fa">این می تواند برای حرکت سر استفاده شود. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Detta kan användas för en huvudrörelse. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это может быть использовано для движения головы. [AUTOTRANSLATED]</column>
@@ -7981,7 +7981,7 @@ It is also used to name martial arts stances. To command someone to strike a sta
       <column name="antonyms"></column>
       <column name="see_also">{tlhIl:n}, {tlhIl:v}</column>
       <column name="notes">This is a rare mineral which is mined.</column>
-      <column name="notes_de">Dies ist ein seltenes Mineral, das abgebaut wird. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Dies ist ein seltenes Mineral, das abgebaut wird.</column>
       <column name="notes_fa">این ماده معدنی نادر است که استخراج می شود. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Detta är ett sällsynt mineral som bryts. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это редкий минерал, который добывается. [AUTOTRANSLATED]</column>
@@ -8010,7 +8010,7 @@ It is also used to name martial arts stances. To command someone to strike a sta
       <column name="entry_name">toppa'</column>
       <column name="part_of_speech">n:anim</column>
       <column name="definition">type of animal, topah</column>
-      <column name="definition_de">Topah</column>
+      <column name="definition_de">Topah (Tiersorte)</column>
       <column name="definition_fa">نوع حیوانات، topah [AUTOTRANSLATED]</column>
       <column name="definition_sv">ett slags djur, topah</column>
       <column name="definition_ru">type of animal, topah [AUTOTRANSLATED]</column>
@@ -8020,7 +8020,7 @@ It is also used to name martial arts stances. To command someone to strike a sta
       <column name="antonyms"></column>
       <column name="see_also"></column>
       <column name="notes">There is an idiom, {tlhIb; toppa' rur}.</column>
-      <column name="notes_de">Es gibt eine Redewendung, {tlhIb; toppa' rur}. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Es gibt eine Redewendung: {tlhIb; toppa' rur}.</column>
       <column name="notes_fa">یک اصطلاح ، {tlhIb; toppa' rur} وجود دارد. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Det finns ett formspråk, {tlhIb; toppa' rur}. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Существует идиома {tlhIb; toppa' rur}. [AUTOTRANSLATED]</column>
@@ -8376,7 +8376,7 @@ Pitching downwards is indicated using a negative angle (see {taH:v:2}).</column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
       <column name="notes">He is father to Pok ({paq:n:2,name}).</column>
-      <column name="notes_de">Er ist Vater von Pok ({paq:n:2,name}). [AUTOTRANSLATED]</column>
+      <column name="notes_de">Dies ist der Vater von Pok ({paq:n:2,name}).</column>
       <column name="notes_fa">او پدر پوک ({paq:n:2,name}) است. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Han är far till Pok ({paq:n:2,name}). [AUTOTRANSLATED]</column>
       <column name="notes_ru">Он отец Пок ({paq:n:2,name}). [AUTOTRANSLATED]</column>
@@ -8551,7 +8551,7 @@ Pitching downwards is indicated using a negative angle (see {taH:v:2}).</column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
       <column name="notes">This is the 3rd rank of {yaS:n}.</column>
-      <column name="notes_de">Dies ist der 3. Rang von {yaS:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Dies ist der 3. Rang von {yaS:n}.</column>
       <column name="notes_fa">این رتبه سوم {yaS:n} است. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Detta är den tredje rankningen av {yaS:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это 3-й ранг {yaS:n}. [AUTOTRANSLATED]</column>
@@ -8590,7 +8590,7 @@ Pitching downwards is indicated using a negative angle (see {taH:v:2}).</column>
       <column name="antonyms"></column>
       <column name="see_also">{'erwI'Daq:n}, {relleghDaq:n}</column>
       <column name="notes">This refers to a moment of clarity between two warriors on the field of battle.[2]</column>
-      <column name="notes_de">Dies bezieht sich auf einen Moment der Klarheit zwischen zwei Kriegern auf dem Schlachtfeld.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_de">Dies bezieht sich auf einen Moment der Klarheit zwischen zwei Kriegern auf dem Schlachtfeld.[2]</column>
       <column name="notes_fa">این به لحظه شفافیت بین دو جنگجو در میدان نبرد اشاره دارد.[2] [AUTOTRANSLATED]</column>
       <column name="notes_sv">Detta hänvisar till ett ögonblick av tydlighet mellan två krigare på stridsfältet.[2] [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это относится к моменту ясности между двумя воинами на поле битвы.[2] [AUTOTRANSLATED]</column>
@@ -8943,7 +8943,7 @@ Pitching downwards is indicated using a negative angle (see {taH:v:2}).</column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
       <column name="notes">This idiomatic expression literally means "to chew ligament".</column>
-      <column name="notes_de">Dieser idiomatische Ausdruck bedeutet wörtlich "Band kauen". [AUTOTRANSLATED]</column>
+      <column name="notes_de">Dieser idiomatische Ausdruck bedeutet wörtlich "Band kauen".</column>
       <column name="notes_fa">این اصطلاح اصطلاحاً به معنای واقعی کلمه به معنای "جویدن رباط" است. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Detta idiomatiska uttryck betyder bokstavligen "att tugga ligament". [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это идиоматическое выражение буквально означает «жевать связку». [AUTOTRANSLATED]</column>
@@ -9102,7 +9102,7 @@ Pitching downwards is indicated using a negative angle (see {taH:v:2}).</column>
       <column name="antonyms">{pa'logh:n}</column>
       <column name="see_also">{pIq:n}</column>
       <column name="notes">In comparison, {'op pIq:n@@'op:n, pIq:n} means "at some point in the future".</column>
-      <column name="notes_de">Im Vergleich dazu bedeutet {'op pIq:n@@'op:n, pIq:n} "irgendwann in der Zukunft". [AUTOTRANSLATED]</column>
+      <column name="notes_de">Im Vergleich dazu bedeutet {'op pIq:n@@'op:n, pIq:n} "irgendwann in der Zukunft".</column>
       <column name="notes_fa">در مقایسه ، {'op pIq:n@@'op:n, pIq:n} به معنای "در برخی از نقطه های آینده" است. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Som jämförelse betyder {'op pIq:n@@'op:n, pIq:n} "någon gång i framtiden". [AUTOTRANSLATED]</column>
       <column name="notes_ru">Для сравнения, {'op pIq:n@@'op:n, pIq:n} означает «в какой-то момент в будущем». [AUTOTRANSLATED]</column>
@@ -9142,7 +9142,7 @@ Pitching downwards is indicated using a negative angle (see {taH:v:2}).</column>
       <column name="antonyms"></column>
       <column name="see_also">{tuch rItwI':n}</column>
       <column name="notes">For Klingons, to prophesize is to be able to "summon" the future somehow.</column>
-      <column name="notes_de">Prophezeiung bedeutet für Klingonen, die Zukunft irgendwie "beschwören" zu können. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Prophezeiung bedeutet für Klingonen, die Zukunft irgendwie "beschwören" zu können.</column>
       <column name="notes_fa">برای کلینگون ، پیشگویی این است که بتوانیم آینده را به نوعی "احضار" کنیم. [AUTOTRANSLATED]</column>
       <column name="notes_sv">För Klingons är att förutsäga att på något sätt kunna "kalla" framtiden. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Для клингонов пророчество - это как-то «вызвать» будущее. [AUTOTRANSLATED]</column>
@@ -9181,7 +9181,7 @@ Pitching downwards is indicated using a negative angle (see {taH:v:2}).</column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
       <column name="notes">This could also be shortened to {rItwI':n:nolink} if the context is clear.</column>
-      <column name="notes_de">Dies könnte auch zu {rItwI':n:nolink} gekürzt werden, wenn der Kontext klar ist. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Dies könnte auch zu {rItwI':n:nolink} gekürzt werden, wenn der Kontext klar ist.</column>
       <column name="notes_fa">اگر متن روشن باشد ، می تواند به {rItwI':n:nolink} نیز کوتاه شود. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Detta kan också förkortas till {rItwI':n:nolink} om sammanhanget är klart. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это также может быть сокращено до {rItwI':n:nolink}, если контекст понятен. [AUTOTRANSLATED]</column>


### PR DESCRIPTION
fixed autotranslated entries for new words in German, plus corrected some other autotranslated entries.
Note for @De7vID  (or @dlyongemallo ?):
The note for deny/tem is only useful in English because "deny" is ambiguous. The chosen German translation "abstreiten" makes the meaning clear, so the addition is not very helpful. A user might think like "why do they say that?" - [I don't know about the other languages.] -> I removed the entry and moved the additional words into the search tag.