### PR TITLE
Note on avoiding formal "Sie"

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,12 +81,12 @@ repo) to see if any syllables have been added which are not available in the
 [TTS](https://github.com/De7vID/klingon-assistant-tts-android).
 
 Conventions for German translators
+
 All adjectivally used verbs should be translated as "[quality] sein", not just 
-the uality as an adjective.
+the quality as an adjective.
 
 Any suggestions and recommendations ("for x, use y") should be written in a 
-neutral form. The autotranslated sentences use the very formal "Sie" which 
-looks too formal for this app. To avoid discussions when using the informal 
-"du", such phrases can be rearranged into general statements like "dieses Wort
-wird verwendet" ("this word is used").
-
+neutral form ("for x, y is used"). The autotranslated sentences use the very 
+formal "Sie" which looks too formal for this app. To avoid discussions about 
+using the informal "du", such phrases can be rearranged into general statements 
+like "dieses Wort wird verwendet" ("this word is used").

--- a/README.md
+++ b/README.md
@@ -79,3 +79,14 @@ Optionally, one may also run the `check_audio_files.pl` script (in the
 `scripts` directory of the [main](https://github.com/De7vID/klingon-assistant)
 repo) to see if any syllables have been added which are not available in the
 [TTS](https://github.com/De7vID/klingon-assistant-tts-android).
+
+Conventions for German translators
+All adjectivally used verbs should be translated as "[quality] sein", not just 
+the uality as an adjective.
+
+Any suggestions and recommendations ("for x, use y") should be written in a 
+neutral form. The autotranslated sentences use the very formal "Sie" which 
+looks too formal for this app. To avoid discussions when using the informal 
+"du", such phrases can be rearranged into general statements like "dieses Wort
+wird verwendet" ("this word is used").
+

--- a/README.md
+++ b/README.md
@@ -80,12 +80,16 @@ Optionally, one may also run the `check_audio_files.pl` script (in the
 repo) to see if any syllables have been added which are not available in the
 [TTS](https://github.com/De7vID/klingon-assistant-tts-android).
 
-Conventions for German translators
+Conventions for translators
+===========================
 
-All adjectivally used verbs should be translated as "[quality] sein", not just 
+German
+------
+
+ - All adjectivally used verbs should be translated as "[quality] sein", not just 
 the quality as an adjective.
 
-Any suggestions and recommendations ("for x, use y") should be written in a 
+ - Any suggestions and recommendations ("for x, use y") should be written in a 
 neutral form ("for x, y is used"). The autotranslated sentences use the very 
 formal "Sie" which looks too formal for this app. To avoid discussions about 
 using the informal "du", such phrases can be rearranged into general statements 


### PR DESCRIPTION
I've added a note for German editors to avoid the formal "Sie" ("you") because it looks pretty weird in such an app. Not because it's a Klingon app, but just in general and in digital Apps, formal "Sie" is usually not used. You would encounter it on government pages or in online sores maybe. To avoid any discussion if Du or Sie is better, I suggest using a general statement avoiding the direct address of the reader.