### PR TITLE
Temporarily strip fi definitions until Java code changes are made.

### DIFF
--- a/generate_db.sh
+++ b/generate_db.sh
@@ -52,8 +52,10 @@ fi
 # xml file.
 TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp/}klingon-assistant-data.XXXXXXXX")
 cp $SOURCE_DIR/mem-*.xml $TMP_DIR
+cp $SOURCE_DIR/strip_fi.sh $TMP_DIR
 cp $SOURCE_DIR/renumber.py $TMP_DIR
 cd $TMP_DIR
+./strip_fi.sh
 ./renumber.py
 cat mem-00-header.xml mem-01-b.xml mem-02-ch.xml mem-03-D.xml mem-04-gh.xml mem-05-H.xml mem-06-j.xml mem-07-l.xml mem-08-m.xml mem-09-n.xml mem-10-ng.xml mem-11-p.xml mem-12-q.xml mem-13-Q.xml mem-14-r.xml mem-15-S.xml mem-16-t.xml mem-17-tlh.xml mem-18-v.xml mem-19-w.xml mem-20-y.xml mem-21-a.xml mem-22-e.xml mem-23-I.xml mem-24-o.xml mem-25-u.xml mem-26-suffixes.xml mem-27-extra.xml mem-28-examples.xml mem-29-footer.xml > $TMP_DIR/mem.xml
 cp $TMP_DIR/EXTRA $SOURCE_DIR

--- a/mem-20-y.xml
+++ b/mem-20-y.xml
@@ -2783,8 +2783,8 @@ Yleensä kun olotilaa kuvaavaa verbiä käytetään välttämättömänä, sen k
       <column name="definition_sv">tribbel</column>
       <column name="definition_ru">Триббл</column>
       <column name="definition_zh_HK">符段 [AUTOTRANSLATED]</column>
-      <column name="definition_pt">eräs eläin, tribble</column>
-      <column name="definition_fi">trible</column>
+      <column name="definition_pt">tribble</column>
+      <column name="definition_fi">eräs eläin, trible</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghIlo'meH:n:extcan}</column>

--- a/strip_fi.sh
+++ b/strip_fi.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+sed -i -E ':a;N;$!ba;s:      <column name="[^"]*_fi">[^<]*</column>\n::g' mem-*.xml

--- a/xml2sql.pl
+++ b/xml2sql.pl
@@ -36,7 +36,8 @@ print "PRAGMA foreign_keys=OFF;\n".
       "BEGIN TRANSACTION;\n".
       "CREATE TABLE IF NOT EXISTS \"android_metadata\" (\"locale\" TEXT DEFAULT 'en_US');\n".
       "INSERT INTO android_metadata VALUES('en_US');\n".
-      "CREATE TABLE IF NOT EXISTS \"mem\" (\"_id\" INTEGER PRIMARY KEY,\"entry_name\" TEXT,\"part_of_speech\" TEXT,\"definition\" TEXT,\"synonyms\" TEXT,\"antonyms\" TEXT,\"see_also\" TEXT,\"notes\" TEXT,\"hidden_notes\" TEXT,\"components\" TEXT,\"examples\" TEXT,\"search_tags\" TEXT,\"source\" TEXT,\"definition_de\" TEXT,\"notes_de\" TEXT,\"examples_de\" TEXT,\"search_tags_de\" TEXT,\"definition_fa\" TEXT,\"notes_fa\" TEXT,\"examples_fa\" TEXT,\"search_tags_fa\" TEXT,\"definition_sv\" TEXT,\"notes_sv\" TEXT,\"examples_sv\" TEXT,\"search_tags_sv\" TEXT,\"definition_ru\" TEXT,\"notes_ru\" TEXT,\"examples_ru\" TEXT,\"search_tags_ru\" TEXT,\"definition_zh_HK\" TEXT,\"notes_zh_HK\" TEXT,\"examples_zh_HK\" TEXT,\"search_tags_zh_HK\" TEXT,\"definition_pt\" TEXT,\"notes_pt\" TEXT,\"examples_pt\" TEXT,\"search_tags_pt\" TEXT DEFAULT \"\",\"definition_fi\" TEXT,\"notes_fi\" TEXT,\"examples_fi\" TEXT,\"search_tags_fi\" TEXT DEFAULT \"\");\n";
+      "CREATE TABLE IF NOT EXISTS \"mem\" (\"_id\" INTEGER PRIMARY KEY,\"entry_name\" TEXT,\"part_of_speech\" TEXT,\"definition\" TEXT,\"synonyms\" TEXT,\"antonyms\" TEXT,\"see_also\" TEXT,\"notes\" TEXT,\"hidden_notes\" TEXT,\"components\" TEXT,\"examples\" TEXT,\"search_tags\" TEXT,\"source\" TEXT,\"definition_de\" TEXT,\"notes_de\" TEXT,\"examples_de\" TEXT,\"search_tags_de\" TEXT,\"definition_fa\" TEXT,\"notes_fa\" TEXT,\"examples_fa\" TEXT,\"search_tags_fa\" TEXT,\"definition_sv\" TEXT,\"notes_sv\" TEXT,\"examples_sv\" TEXT,\"search_tags_sv\" TEXT,\"definition_ru\" TEXT,\"notes_ru\" TEXT,\"examples_ru\" TEXT,\"search_tags_ru\" TEXT,\"definition_zh_HK\" TEXT,\"notes_zh_HK\" TEXT,\"examples_zh_HK\" TEXT,\"search_tags_zh_HK\" TEXT,\"definition_pt\" TEXT,\"notes_pt\" TEXT,\"examples_pt\" TEXT,\"search_tags_pt\" TEXT);\n";
+      # "CREATE TABLE IF NOT EXISTS \"mem\" (\"_id\" INTEGER PRIMARY KEY,\"entry_name\" TEXT,\"part_of_speech\" TEXT,\"definition\" TEXT,\"synonyms\" TEXT,\"antonyms\" TEXT,\"see_also\" TEXT,\"notes\" TEXT,\"hidden_notes\" TEXT,\"components\" TEXT,\"examples\" TEXT,\"search_tags\" TEXT,\"source\" TEXT,\"definition_de\" TEXT,\"notes_de\" TEXT,\"examples_de\" TEXT,\"search_tags_de\" TEXT,\"definition_fa\" TEXT,\"notes_fa\" TEXT,\"examples_fa\" TEXT,\"search_tags_fa\" TEXT,\"definition_sv\" TEXT,\"notes_sv\" TEXT,\"examples_sv\" TEXT,\"search_tags_sv\" TEXT,\"definition_ru\" TEXT,\"notes_ru\" TEXT,\"examples_ru\" TEXT,\"search_tags_ru\" TEXT,\"definition_zh_HK\" TEXT,\"notes_zh_HK\" TEXT,\"examples_zh_HK\" TEXT,\"search_tags_zh_HK\" TEXT,\"definition_pt\" TEXT,\"notes_pt\" TEXT,\"examples_pt\" TEXT,\"search_tags_pt\" TEXT,\"definition_fi\" TEXT,\"notes_fi\" TEXT,\"examples_fi\" TEXT,\"search_tags_fi\" TEXT);\n";
 
 # Regex to check "en" language fields.
 $valid_en = qr/^[A-Za-z0-9 '":;,.\-?!_\/\()@=%&*{}\[\]<>▶\nàéü+×÷#神舟]*$/;
@@ -108,11 +109,11 @@ foreach $e (@{$data->{database}->{mem}})
     print $e->{definition_pt}, "','";
     print $e->{notes_pt}, "','";
     print $e->{examples_pt}, "','";
-    print $e->{search_tags_pt}, "','";
-    print $e->{definition_fi}, "','";
-    print $e->{notes_fi}, "','";
-    print $e->{examples_fi}, "','";
-    print $e->{search_tags_fi}, "');\n";
+    print $e->{search_tags_pt}, "');\n";
+    # print $e->{definition_fi}, "','";
+    # print $e->{notes_fi}, "','";
+    # print $e->{examples_fi}, "','";
+    # print $e->{search_tags_fi}, "');\n";
 }
 
 # print sql file footer


### PR DESCRIPTION
Also fix accidental overwriting of {yIH:n} pt definition by fi.