### PR TITLE
fix incorrect link from {tlhombuS:n} to {mIQ:n}, fix some de autotranslated notes.

### DIFF
--- a/mem-17-tlh.xml
+++ b/mem-17-tlh.xml
@@ -4277,8 +4277,8 @@ Voidaan sanoa joko {B tlhogh A:sen:nolink} "{A:sen:nolink} naimisiin {B:sen:noli
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
-      <column name="notes">This is made by coating a block of {tlhagh:n} with {ngat:n:2} and {tIr:n}, then {mIQ:n}.[1, p.93]</column>
-      <column name="notes_de">Dies erfolgt durch Beschichten eines Blocks von {tlhagh:n} mit {ngat:n:2} und {tIr:n}, dann {mIQ:n}.[1, p.93] [AUTOTRANSLATED]</column>
+      <column name="notes">This is made by coating a block of {tlhagh:n} with {ngat:n:2} and {tIr:n}, then {mIQ:v}.[1, p.93]</column>
+      <column name="notes_de">Dies erfolgt durch Beschichten eines Blocks von {tlhagh:n} mit {ngat:n:2} und {tIr:n}, dann {mIQ:v}.[1, p.93]</column>
       <column name="notes_fa"></column>
       <column name="notes_sv"></column>
       <column name="notes_ru">Это делается путем покрытия блока {tlhagh:n} {ngat:n:2} и {tIr:n}, затем {mIQ:n}. [1, p.93] [AUTOTRANSLATED]</column>
@@ -4365,7 +4365,7 @@ Voidaan sanoa joko {B tlhogh A:sen:nolink} "{A:sen:nolink} naimisiin {B:sen:noli
       <column name="antonyms"></column>
       <column name="see_also"></column>
       <column name="notes">According to the glossary to {A Burning House:src}, this is much larger than a {targh:n}, more difficult to subdue, and is sometimes used as a riding beast.</column>
-      <column name="notes_de">Laut dem Glossar zu {A Burning House:src} ist dieses viel größer als ein {targh:n}, schwieriger zu bezwingen und wird manchmal als Reittier verwendet. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Laut dem Glossar zu {A Burning House:src} ist dieses viel größer als ein {targh:n}, schwieriger zu bezwingen und wird manchmal als Reittier verwendet.</column>
       <column name="notes_fa">مطابق واژه نامه {A Burning House:src} ، این بسیار بزرگتر از {targh:n} است ، مطیع کردن آن دشوارتر است ، و گاهی اوقات به عنوان جانور سواری استفاده می شود. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Enligt ordlistan till {A Burning House:src} är detta mycket större än en {targh:n}, svårare att dämpa och används ibland som riddjur. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
@@ -4494,7 +4494,7 @@ Voidaan sanoa joko {B tlhogh A:sen:nolink} "{A:sen:nolink} naimisiin {B:sen:noli
       <column name="antonyms"></column>
       <column name="see_also">{tlhop:n:1}, {ghom:v}</column>
       <column name="notes">This is just an extension of {tlhop:n:1} in a specific context. The idea is that a public area would be in front of some barrier used to keep the public out, while the private area would be on the other side.</column>
-      <column name="notes_de">Dies ist nur eine Erweiterung von {tlhop:n:1} in einem bestimmten Kontext. Die Idee ist, dass sich ein öffentlicher Bereich vor einer Barriere befindet, die dazu dient, die Öffentlichkeit fernzuhalten, während sich der private Bereich auf der anderen Seite befindet. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Dies ist nur eine Erweiterung von {tlhop:n:1} in einem bestimmten Kontext. Die Idee ist, dass sich ein öffentlicher Bereich vor einer Barriere befindet, die dazu dient, die Öffentlichkeit fernzuhalten, während sich der private Bereich auf der anderen Seite befindet.</column>
       <column name="notes_fa">این فقط یک پسوند {tlhop:n:1} در یک زمینه خاص است. ایده این است که یک منطقه عمومی در مقابل برخی از موانعی قرار دارد که از آن استفاده می شود تا عموم مردم را بیرون نگه دارد ، در حالی که منطقه خصوصی در آن طرف است. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Detta är bara en förlängning av {tlhop:n:1} i ett specifikt sammanhang. Tanken är att ett offentligt område skulle ligga framför en barriär som används för att hålla allmänheten ute, medan det privata området skulle vara på andra sidan. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это просто расширение {tlhop:n:1} в определенном контексте. Идея состоит в том, что общественная зона будет находиться перед каким-то барьером, используемым для удержания публики, в то время как частная зона будет на другой стороне. [AUTOTRANSLATED]</column>


### PR DESCRIPTION
In the entry of tlhombuS, the word mIQ (deepfry) was linked to the noun mIQ, forehead. I fixed this, and remobed some autotranslated tags.