### PR TITLE
German translations qepHom 2021

### DIFF
--- a/mem-03-D.xml
+++ b/mem-03-D.xml
@@ -4041,7 +4041,7 @@ Tätä verbiä voidaan soveltaa lentokoneisiin, joista ks. {Der:v:2}.[1] [AUTOTR
       <column name="entry_name">Deryat</column>
       <column name="part_of_speech">n</column>
       <column name="definition">program, agenda, schedule</column>
-      <column name="definition_de">Programm, Tagesordnung, Zeitplan [AUTOTRANSLATED]</column>
+      <column name="definition_de">Programm, Tagesordnung, Zeitplan</column>
       <column name="definition_fa">برنامه، دستور کار، برنامه [AUTOTRANSLATED]</column>
       <column name="definition_sv">program, agenda, schema [AUTOTRANSLATED]</column>
       <column name="definition_ru">программа, повестка дня, расписание [AUTOTRANSLATED]</column>
@@ -8174,7 +8174,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
         <column name="entry_name">Doj tlhum</column>
         <column name="part_of_speech">n:deriv</column>
         <column name="definition">bundle</column>
-        <column name="definition_de">bündeln [AUTOTRANSLATED]</column>
+        <column name="definition_de">Bündel</column>
         <column name="definition_fa">دسته [AUTOTRANSLATED]</column>
         <column name="definition_sv">bunt [AUTOTRANSLATED]</column>
         <column name="definition_ru">пучок [AUTOTRANSLATED]</column>
@@ -8262,7 +8262,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="entry_name">Dol</column>
       <column name="part_of_speech">n</column>
       <column name="definition">entity, whole</column>
-      <column name="definition_de">Einheit, das Ganze(s)</column>
+      <column name="definition_de">Einheit, das Ganze</column>
       <column name="definition_fa">نهاد، کل [AUTOTRANSLATED]</column>
       <column name="definition_sv">väsen, självständig helhet</column>
       <column name="definition_ru">сущность, целый(как определение размера)</column>
@@ -8709,7 +8709,7 @@ This was defined as "side". The clarification "direction, face" was added to dif
           <column name="entry_name">Doq bIQtIq bIQ</column>
           <column name="part_of_speech">sen:idiom</column>
           <column name="definition">something momentous has happened</column>
-          <column name="definition_de">etwas schwerwiegendes ist geschehen</column>
+          <column name="definition_de">etwas Schwerwiegendes ist geschehen</column>
           <column name="definition_fa">چیزی مهم است اتفاق افتاده است [AUTOTRANSLATED]</column>
           <column name="definition_sv">något som har hänt [AUTOTRANSLATED]</column>
           <column name="definition_ru">случилось что-то важное</column>
@@ -8901,7 +8901,7 @@ This was defined as "side". The clarification "direction, face" was added to dif
       <column name="entry_name">DoQmIv</column>
       <column name="part_of_speech">n</column>
       <column name="definition">sink for cleaning hands, face, food, etc.</column>
-      <column name="definition_de">Becken, Spüle, z.B. in Küche oder Bad</column>
+      <column name="definition_de">Becken, Wanne, Spüle, z.B. in Küche oder Bad</column>
       <column name="definition_fa">غرق برای تمیز کردن دست، چهره، غذا و غیره [AUTOTRANSLATED]</column>
       <column name="definition_sv">handfat för rengöring av händer, ansikte, mat, etc. [AUTOTRANSLATED]</column>
       <column name="definition_ru">раковина для мытья рук, лица, еды и т. д. [AUTOTRANSLATED]</column>


### PR DESCRIPTION
Added or fixed German translations for new words of qepHom 2021, also made some random minor corrections on other German translations.