### PR TITLE
German translations qepHom2021

### DIFF
--- a/mem-05-H.xml
+++ b/mem-05-H.xml
@@ -1239,7 +1239,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="antonyms"></column>
       <column name="see_also">{Haq:n}, {Haq:v:2}</column>
       <column name="notes">This word has a negative connotation in Klingon culture.[1]</column>
-      <column name="notes_de">Dieses Wort hat eine negative Konnotation in der klingonischen Kultur.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_de">Dieses Wort hat eine negative Konnotation in der klingonischen Kultur.[1]</column>
       <column name="notes_fa">این کلمه در فرهنگ کلینگون تأثیر منفی دارد.[1] [AUTOTRANSLATED]</column>
       <column name="notes_sv">Detta ord har en negativ konnotation i Klingon-kulturen.[1] [AUTOTRANSLATED]</column>
       <column name="notes_ru">Слово имеет негативный оттенок в Клингонской культуре.[1]</column>
@@ -1282,7 +1282,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="antonyms"></column>
       <column name="see_also">{mun:v}, {nIS:v}, {Haq:v:1}</column>
       <column name="notes">This word has a negative connotation in Klingon culture.[1]</column>
-      <column name="notes_de">Dieses Wort hat eine negative Konnotation in der klingonischen Kultur.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_de">Dieses Wort hat eine negative Konnotation in der klingonischen Kultur.[1]</column>
       <column name="notes_fa">این کلمه در فرهنگ کلینگون تأثیر منفی دارد.[1] [AUTOTRANSLATED]</column>
       <column name="notes_sv">Detta ord har en negativ konnotation i Klingon-kulturen.[1] [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это слово имеет отрицательный оттенок в клингонской культуре.[1] [AUTOTRANSLATED]</column>
@@ -1314,7 +1314,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="entry_name">Haq</column>
       <column name="part_of_speech">v:3,t,slang</column>
       <column name="definition">tinker</column>
-      <column name="definition_de">basteln [AUTOTRANSLATED]</column>
+      <column name="definition_de">basteln</column>
       <column name="definition_fa">قلع و قمع [AUTOTRANSLATED]</column>
       <column name="definition_sv">knåpa [AUTOTRANSLATED]</column>
       <column name="definition_ru">возиться [AUTOTRANSLATED]</column>
@@ -1325,7 +1325,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
       <column name="notes">This literally means "perform surgery on" ({Haq:v:1}) and is used only if the tinkerer really knows what they're doing.</column>
-      <column name="notes_de"></column>
+      <column name="notes_de">Dies bedeutet wörtlich "jemanden operieren" ({Haq:v:1}) und wird nur verwendet, wenn die bastelnde Person genau weiß, was sie macht.</column>
       <column name="notes_fa"></column>
       <column name="notes_sv"></column>
       <column name="notes_ru"></column>


### PR DESCRIPTION
Added or fixed German translations for new words of qepHom 2021, also made some random minor corrections on other German translations.