### PR TITLE
German translations qepHom2021

### DIFF
--- a/mem-08-m.xml
+++ b/mem-08-m.xml
@@ -3466,7 +3466,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="entry_name">ma'egh</column>
       <column name="part_of_speech">n</column>
       <column name="definition">premiere</column>
-      <column name="definition_de">premiere [AUTOTRANSLATED]</column>
+      <column name="definition_de">Premiere, Erstaufführung</column>
       <column name="definition_fa">premiere [AUTOTRANSLATED]</column>
       <column name="definition_sv">premiere [AUTOTRANSLATED]</column>
       <column name="definition_ru">premiere [AUTOTRANSLATED]</column>
@@ -3520,7 +3520,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="antonyms"></column>
       <column name="see_also">{ma'veq:n}, {'aDanjI':n:extcan}</column>
       <column name="notes">A death ritual that allows one who has lost honor to die well and go to Sto-Vo-Kor by being honorably killed by a House-mate or someone equally close.</column>
-      <column name="notes_de">Ein Todesritual, das es jemandem, der die Ehre verloren hat, ermöglicht, gut zu sterben und nach Sto-Vo-Kor zu gehen, indem er von einem Mitbewohner oder einer ähnlich nahen Person ehrenvoll getötet wird. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Ein Todesritual, das es jemandem, der die Ehre verloren hat, ermöglicht, gut zu sterben und nach Sto-Vo-Kor zu gehen, indem er von einem Mitbewohner oder einer ähnlich nahen Person ehrenvoll getötet wird.</column>
       <column name="notes_fa">مراسم مرگ که به کسی که افتخار خود را از دست داده اجازه می دهد تا به خوبی مرد و به استو-و-کور برود با افتخار توسط یک همسر مجلس یا کسی که به همان اندازه نزدیک کشته شود. [AUTOTRANSLATED]</column>
       <column name="notes_sv">En dödsritual som gör att en som har tappat ära att dö väl och gå till Sto-Vo-Kor genom att hederligt dödas av en kamrat eller någon lika nära. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Смертельный ритуал, который позволяет тому, кто потерял честь, умереть достойно и почить в Стовокорре, будучи убитым. Ритуал проводит член дома, в котором состоит Клингон, или кто-то достаточно близкий.</column>


### PR DESCRIPTION
Added or fixed German translations for new words of qepHom 2021, also made some random minor corrections on other German translations.