### PR TITLE
German translations qepHom2021

### DIFF
--- a/mem-10-ng.xml
+++ b/mem-10-ng.xml
@@ -2450,7 +2450,7 @@ No {paq'batlh:src}, a expressão {qul ngeng HeH:n:nolink} é usada para se refer
       <column name="entry_name">ngeq</column>
       <column name="part_of_speech">v:t_c</column>
       <column name="definition">store, hoard, cache</column>
-      <column name="definition_de">store, hoard, cache [AUTOTRANSLATED]</column>
+      <column name="definition_de">speichern, horten, lagern</column>
       <column name="definition_fa">store, hoard, cache [AUTOTRANSLATED]</column>
       <column name="definition_sv">store, hoard, cache [AUTOTRANSLATED]</column>
       <column name="definition_ru">store, hoard, cache [AUTOTRANSLATED]</column>
@@ -2463,7 +2463,9 @@ No {paq'batlh:src}, a expressão {qul ngeng HeH:n:nolink} é usada para se refer
       <column name="notes">This is used for the act of moving or putting things somewhere to store them. There is a subtle difference between this and {pol:v}, which refers to just keeping something somewhere. For example, {Soj Dangeq:sen@@Soj:n:1, Da-:v, ngeq:v} might be said to someone putting groceries into the food storage room ({Soj polmeH pa':n}). But {Soj Dapol:sen@@Soj:n:1, Da-:v, pol:v} might be said to someone whose groceries are already in the storage room.[1]
 
 This is also used with {qaw:n} idiomatically to refer to memorization. Once the thing is memorized, {pol:v:nolink} might make more sense. Both of these words are also used in the computer sense to mean "save" or "store" a file on a storage medium[1]</column>
-      <column name="notes_de"></column>
+      <column name="notes_de">Dies wird verwendet, wenn man Sachen irgendwo hinlegt, um sie dort zu lagern. Es gibt einen feinen Unterscheid zwischen dies und {pol:v}, welches sich nur auf den Verbleib der Sachen irgendwo bezieht. Zum Beispiel kann man {Soj Dangeq:sen@@Soj:n:1, Da-:v, ngeq:v} zu jemandem sagen, der gerade seine Einkäufe in die Speisekammer legt ({Soj polmeH pa':n}). Aber {Soj Dapol:sen@@Soj:n:1, Da-:v, pol:v} sagt man zu jemandem, wenn die Speisen bereits im Schrank liegen.[1]
+
+Das Verb kann auch in Kombination mit {qaw:n} verwendet werden im Sinne von auswendig lernen. Sobald man sich aber etwas gemerkt hat, ist {pol:v:nolink} wohl passender. Beide Verben können verwendet werden, wenn es darum geht, Daten auf einem Computer oder ähnlich zu speichern.[1]</column></column>
       <column name="notes_fa"></column>
       <column name="notes_sv"></column>
       <column name="notes_ru"></column>
@@ -2474,7 +2476,8 @@ This is also used with {qaw:n} idiomatically to refer to memorization. Once the 
       <column name="components"></column>
       <column name="examples">
 {ghuQ ngeqpu' qawwIj:sen@@ghuQ:n, ngeq:v, -pu':v, qaw:n, -wIj:n} "I've memorized the poem" (literally, "my memory has stored the poem")</column>
-      <column name="examples_de"></column>
+      <column name="examples_de">
+{ghuQ ngeqpu' qawwIj:sen@@ghuQ:n, ngeq:v, -pu':v, qaw:n, -wIj:n} "Ich habe das Gedicht gelernt" (wörtlich, "mein Gedächtnis hat das Gedicht eingelagert")</column>
       <column name="examples_fa"></column>
       <column name="examples_sv"></column>
       <column name="examples_ru"></column>
@@ -4157,10 +4160,10 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="entry_name">ngolpel</column>
       <column name="part_of_speech">n</column>
       <column name="definition">sit-up</column>
-      <column name="definition_de">sit-up [AUTOTRANSLATED]</column>
-      <column name="definition_fa">sit-up [AUTOTRANSLATED]</column>
-      <column name="definition_sv">sit-up [AUTOTRANSLATED]</column>
-      <column name="definition_ru">sit-up [AUTOTRANSLATED]</column>
+      <column name="definition_de">Sit-up, Rumpfbeugen</column>
+      <column name="definition_fa">درازنشست [AUTOTRANSLATED]</column>
+      <column name="definition_sv">situp [AUTOTRANSLATED]</column>
+      <column name="definition_ru">Подъём корпуса</column>
       <column name="definition_zh_HK">sit-up [AUTOTRANSLATED]</column>
       <column name="definition_pt">sit-up [AUTOTRANSLATED]</column>
       <column name="definition_fi">sit-up [AUTOTRANSLATED]</column>


### PR DESCRIPTION
Added or fixed German translations for new words of qepHom 2021, also made some random minor corrections on other German translations.