### PR TITLE
German translations qepHom2021

### DIFF
--- a/mem-12-q.xml
+++ b/mem-12-q.xml
@@ -9169,7 +9169,7 @@ On epäselvää, miksi lauseke käyttää {tuQmoHHa':v:nolink} eikä {tuQHa'moH:
       <column name="antonyms"></column>
       <column name="see_also"></column>
       <column name="notes">He is a member of the House of Kor ({qor tuq:n:name}).</column>
-      <column name="notes_de">Er ist Mitglied des House of Kor ({qor tuq:n:name}). [AUTOTRANSLATED]</column>
+      <column name="notes_de">Er ist Mitglied des Haus von Kor ({qor tuq:n:name}).</column>
       <column name="notes_fa">وی عضو مجلس کور ({qor tuq:n:name}) است. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Han är medlem i House of Kor ({qor tuq:n:name}). [AUTOTRANSLATED]</column>
       <column name="notes_ru">Является членом дома Кора ({qor tuq:n:name}).</column>
@@ -9201,7 +9201,7 @@ On epäselvää, miksi lauseke käyttää {tuQmoHHa':v:nolink} eikä {tuQHa'moH:
       <column name="entry_name">qol</column>
       <column name="part_of_speech">n:2h</column>
       <column name="definition">collection of segments that are joined together, collocation</column>
-      <column name="definition_de">Sammlung von Segmenten, die zusammengefügt werden, Kollokation [AUTOTRANSLATED]</column>
+      <column name="definition_de">Anordnung von Elementen, die mit einander verbunden sind</column>
       <column name="definition_fa">مجموعه ای از بخش هایی که به هم پیوسته اند، همنشینی [AUTOTRANSLATED]</column>
       <column name="definition_sv">samling av segment som är sammanfogade, samlokalisering [AUTOTRANSLATED]</column>
       <column name="definition_ru">совокупность сегментов, соединенных вместе, словосочетание [AUTOTRANSLATED]</column>
@@ -9256,7 +9256,7 @@ On epäselvää, miksi lauseke käyttää {tuQmoHHa':v:nolink} eikä {tuQHa'moH:
       <column name="antonyms"></column>
       <column name="see_also"></column>
       <column name="notes">This name is untranslated in {KGT:src}, and is possibly a misspelling for {qo'leq:n:name}.</column>
-      <column name="notes_de">Dieser Name ist in {KGT:src} nicht übersetzt und möglicherweise ein Rechtschreibfehler für {qo'leq:n:name}. [AUTOTRANSLATED]</column>
+      <column name="notes_de">Dieser Name ist in {KGT:src} nicht übersetzt und möglicherweise ein Rechtschreibfehler für {qo'leq:n:name}.</column>
       <column name="notes_fa">این نام در {KGT:src} ترجمه نشده است ، و احتمالاً اشتباه برای {qo'leq:n:name} است. [AUTOTRANSLATED]</column>
       <column name="notes_sv">Detta namn är inte översatt i {KGT:src} och är eventuellt en stavfel för {qo'leq:n:name}. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это имя не переведено в {KGT:src} и, возможно, является ошибочным написанием для {qo'leq:n:name}. [AUTOTRANSLATED]</column>
@@ -9662,7 +9662,7 @@ On toinenkin verbi, {gher:v}, jota käytetään luetteloiden ja vastaavien kokoa
       <column name="entry_name">qongmeS</column>
       <column name="part_of_speech">n:being</column>
       <column name="definition">sibling</column>
-      <column name="definition_de">sibling [AUTOTRANSLATED]</column>
+      <column name="definition_de">Geschwister</column>
       <column name="definition_fa">sibling [AUTOTRANSLATED]</column>
       <column name="definition_sv">sibling [AUTOTRANSLATED]</column>
       <column name="definition_ru">sibling [AUTOTRANSLATED]</column>
@@ -14242,7 +14242,7 @@ Kaksi muodin ulkopuolista slangisanaa, joilla on sama merkitys, ovat {Huv:v:2,sl
       <column name="entry_name">qu'vIgh</column>
       <column name="part_of_speech">n:being</column>
       <column name="definition">member of an august body</column>
-      <column name="definition_de">member of an august body [AUTOTRANSLATED]</column>
+      <column name="definition_de">Mitglied einer angesehenen Institution</column>
       <column name="definition_fa">member of an august body [AUTOTRANSLATED]</column>
       <column name="definition_sv">member of an august body [AUTOTRANSLATED]</column>
       <column name="definition_ru">member of an august body [AUTOTRANSLATED]</column>


### PR DESCRIPTION
Added or fixed German translations for new words of qepHom 2021, also made some random minor corrections on other German translations.