### PR TITLE
German translations qepHom2021

### DIFF
--- a/mem-14-r.xml
+++ b/mem-14-r.xml
@@ -4306,7 +4306,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="entry_name">reqwer</column>
       <column name="part_of_speech">n:anim</column>
       <column name="definition">shrimp-like animal</column>
-      <column name="definition_de">garnelenartiges Tier [AUTOTRANSLATED]</column>
+      <column name="definition_de">garnelenartiges Tier</column>
       <column name="definition_fa">حیوانی شبیه میگو [AUTOTRANSLATED]</column>
       <column name="definition_sv">räkliknande djur [AUTOTRANSLATED]</column>
       <column name="definition_ru">креветкоподобное животное [AUTOTRANSLATED]</column>
@@ -5004,7 +5004,7 @@ Tämä on sama sana kuin verbi {ret:v}.[2][1] [AUTOTRANSLATED]</column>
       <column name="entry_name">re'lIng</column>
       <column name="part_of_speech">n</column>
       <column name="definition">instinct, talent, facility, aptitude</column>
-      <column name="definition_de">Instinkt, Talent, Fähigkeit, Begabung [AUTOTRANSLATED]</column>
+      <column name="definition_de">Instinkt, Talent, Fähigkeit, Begabung</column>
       <column name="definition_fa">غریزه، استعداد، امکانات، استعداد [AUTOTRANSLATED]</column>
       <column name="definition_sv">instinkt, talang, anläggning, begåvning [AUTOTRANSLATED]</column>
       <column name="definition_ru">инстинкт, талант, способность, способность [AUTOTRANSLATED]</column>


### PR DESCRIPTION
Added or fixed German translations for new words of qepHom 2021.