### PR TITLE
German translations qepHom2021

### DIFF
--- a/mem-17-tlh.xml
+++ b/mem-17-tlh.xml
@@ -5562,7 +5562,7 @@ Previously, some people believed that this word means "to expel exhaust", based 
       <column name="entry_name">tlhum</column>
       <column name="part_of_speech">v:is</column>
       <column name="definition">be constrained, bound</column>
-      <column name="definition_de">eingeschränkt sein, gebunden sein [AUTOTRANSLATED]</column>
+      <column name="definition_de">gebunden sein</column>
       <column name="definition_fa">مقید بودن، مقید بودن [AUTOTRANSLATED]</column>
       <column name="definition_sv">vara inskränkt, bunden [AUTOTRANSLATED]</column>
       <column name="definition_ru">быть стесненным, связанным [AUTOTRANSLATED]</column>


### PR DESCRIPTION
Added or fixed German translations for new words of qepHom 2021.