### PR TITLE
German translations qepHom2021

### DIFF
--- a/mem-20-y.xml
+++ b/mem-20-y.xml
@@ -4494,7 +4494,7 @@ Katso, kuinka Gowron sanoo tämän: {YouTube video:url:http://youtu.be/HVOJkR51l
       <column name="entry_name">yItQet</column>
       <column name="part_of_speech">n</column>
       <column name="definition">petroleum, crude oil</column>
-      <column name="definition_de">Erdöl, Rohöl [AUTOTRANSLATED]</column>
+      <column name="definition_de">Erdöl, Rohöl</column>
       <column name="definition_fa">نفت، نفت خام [AUTOTRANSLATED]</column>
       <column name="definition_sv">petroleum, råolja [AUTOTRANSLATED]</column>
       <column name="definition_ru">нефть, сырая нефть [AUTOTRANSLATED]</column>


### PR DESCRIPTION
Added or fixed German translations for new words of qepHom 2021.