### PR TITLE
German translations qepHom2021

### DIFF
--- a/mem-25-u.xml
+++ b/mem-25-u.xml
@@ -1766,7 +1766,7 @@ Kolme {'uj:n:nolink} on noin 3'5 ", viisi {'uj:n:nolink} on noin 5'8" ja kuusi {
           <column name="entry_name">'urgh neH</column>
           <column name="part_of_speech">sen:idiom</column>
           <column name="definition">tinker</column>
-          <column name="definition_de">basteln [AUTOTRANSLATED]</column>
+          <column name="definition_de">basteln</column>
           <column name="definition_fa">قلع و قمع [AUTOTRANSLATED]</column>
           <column name="definition_sv">knåpa [AUTOTRANSLATED]</column>
           <column name="definition_ru">возиться [AUTOTRANSLATED]</column>
@@ -1776,7 +1776,7 @@ Kolme {'uj:n:nolink} on noin 3'5 ", viisi {'uj:n:nolink} on noin 5'8" ja kuusi {
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
-          <column name="notes">This slang expression literally means "merely poke/jab". If the context is clear that "shake" in the literal sense is not what is meant, {'urgh:v} alone can be used.[1]</column>
+          <column name="notes">This slang expression literally means "merely poke/jab". If the context is clear that "poke" in the literal sense is not what is meant, {'urgh:v} alone can be used.[1]</column>
           <column name="notes_de"></column>
           <column name="notes_fa"></column>
           <column name="notes_sv"></column>


### PR DESCRIPTION
Added or fixed German translations for new words of qepHom 2021, correct word in English phrase.