### PR TITLE
Book font changes

### DIFF
--- a/book/book-en.tex
+++ b/book/book-en.tex
@@ -3,12 +3,11 @@
 \usepackage[top=1.5cm,bottom=1.5cm,left=1.7cm,right=1.7cm,columnsep=25pt]{geometry}
 \usepackage[fontsize=8pt]{fontsize}
 
-\usepackage[utf8]{inputenc}
-\usepackage[T1]{fontenc}
+\usepackage{fontspec}
+\setmainfont[Ligatures=TeX]{Gentium Basic}
 
 \usepackage[english]{babel}
 
-\usepackage{palatino}
 \usepackage{microtype}
 \usepackage{multicol}
 \usepackage{indentfirst}
@@ -17,7 +16,7 @@
 \usepackage{multirow}
 \usepackage{amssymb}
 
-\usepackage[bf,sf,center]{titlesec}
+\usepackage[bf,center]{titlesec}
 \usepackage{fancyhdr}
 \fancyhead[L]{\textsf{\nouppercase{\rightmark}}}
 \fancyhead[R]{\textsf{\nouppercase{\leftmark}}}


### PR DESCRIPTION
Use `xelatex` instead of `pdflatex` to compile the file.

This assumes that Gentium Basic is installed. In my opinion, it's a good font for writing Klingon. You should be able to change it to any font installed in the system.