### PR TITLE
DE: Duj Raumschiff -> Fahrzeug (more generic term)

### DIFF
--- a/mem-03-D.xml
+++ b/mem-03-D.xml
@@ -10712,7 +10712,7 @@ Tätä verbiä käytetään parantamaan abstraktimpaa luonnetta, kuten tila, tai
       <column name="entry_name">Duj</column>
       <column name="part_of_speech">n:1,klcp1</column>
       <column name="definition">ship, vessel</column>
-      <column name="definition_de">Schiff, Raumschiff</column>
+      <column name="definition_de">Schiff, Fahrzeug</column>
       <column name="definition_fa">کشتی، سفینه، وسیله نقلیه</column>
       <column name="definition_sv">skepp, farkost</column>
       <column name="definition_ru">корабль, судно</column>


### PR DESCRIPTION
Raumschiff is literally "space ship", Duj has been expanded to include more than just space ships, the german should reflect that.