### PR TITLE
DE: ngogh, added "Ziegel"

### DIFF
--- a/mem-10-ng.xml
+++ b/mem-10-ng.xml
@@ -4038,7 +4038,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="entry_name">ngogh</column>
       <column name="part_of_speech">n</column>
       <column name="definition">block, lump, brick</column>
-      <column name="definition_de">Klumpen, Stück, Klotz</column>
+      <column name="definition_de">Klumpen, Stück, Klotz, Ziegel</column>
       <column name="definition_fa">بلوک، توده، آجر [AUTOTRANSLATED]</column>
       <column name="definition_sv">block, klump, kloss</column>
       <column name="definition_ru">блок, кусок, кирпич [AUTOTRANSLATED]</column>


### PR DESCRIPTION
"Brick" is usually understood to be the rectangular building material. "Ziegel" is the german equivalent. The other words don't really convey that meaning.