### PR TITLE
ngav de: Schreibkrampf

### DIFF
--- a/mem-10-ng.xml
+++ b/mem-10-ng.xml
@@ -1514,7 +1514,7 @@ In comparison, the table of contents of a book would be labeled {paq 'ay'mey:n}.
       <column name="entry_name">ngav</column>
       <column name="part_of_speech">n</column>
       <column name="definition">writer's cramp</column>
-      <column name="definition_de">Krampf des Schreibers</column>
+      <column name="definition_de">Schreibkrampf</column>
       <column name="definition_fa">گرفتگی نویسنده [AUTOTRANSLATED]</column>
       <column name="definition_sv">skrivkramp</column>
       <column name="definition_ru">писательская судорога</column>


### PR DESCRIPTION
"Krampf des Schreibers" wäre die wörtliche Übersetzung vom englischen, aber es gibt im deutschen ein eigenes Wort dafür: Schreibkrampf.