### PR TITLE
ngep'oS de: added exception (ship doors)

### DIFF
--- a/mem-10-ng.xml
+++ b/mem-10-ng.xml
@@ -2581,7 +2581,7 @@ No {paq'batlh:src}, a expressão {qul ngeng HeH:n:nolink} é usada para se refer
       <column name="entry_name">ngep'oS</column>
       <column name="part_of_speech">n:reg</column>
       <column name="definition">stairs, stairway (except at ship door)</column>
-      <column name="definition_de">Treppe, Stufen</column>
+      <column name="definition_de">Treppe, Stufen (ausgenommen bei Schiffstüren)</column>
       <column name="definition_fa">پله ها، راه پله ها (به استثنای درب کشتی) [AUTOTRANSLATED]</column>
       <column name="definition_sv">trappa, trappuppgång (utom vid skeppsdörr)</column>
       <column name="definition_ru">лестница, лестница (кроме двери корабля) [AUTOTRANSLATED]</column>


### PR DESCRIPTION
Die Formulierung ist nicht optimal, aber vorher hat die Anmerkung komplett gefehlt.