### PR TITLE
change DE translation

### DIFF
--- a/mem-16-t.xml
+++ b/mem-16-t.xml
@@ -2315,7 +2315,7 @@ Tämä murre on tavallaan puolivälissä tavallisen murteen ja {Qotmagh Sep:n}-m
       <column name="entry_name">taQbang</column>
       <column name="part_of_speech">n:1</column>
       <column name="definition">exhaust</column>
-      <column name="definition_de">Auspuff</column>
+      <column name="definition_de">Abgase</column>
       <column name="definition_fa">اگزوز [AUTOTRANSLATED]</column>
       <column name="definition_sv">avgaser, utsläpp</column>
       <column name="definition_ru">выхлоп</column>


### PR DESCRIPTION
before we knew that {taQbang} can be used for fecal matter, it was not clear if it referred to expelled gas, or a device. The former German definition described a device. The gas makes more sense now.