### PR TITLE
Confirm or translate script

### DIFF
--- a/confirm-or-translate.py
+++ b/confirm-or-translate.py
@@ -47,7 +47,7 @@ for xmlfile in xmlfiles:
                 entry_comment = line.strip()
 
             elif len(definitions) > 0:
-                if "TRANSLATE" in definitions[args.lang]:
+                if "TRANSLATE" in definitions[args.lang] or len(definitions[args.lang]) == 0:
                     print(f"--- {entry_name} ({part_of_speech}) ---", file=stdout)
                     for lang in ["en"] + langs:
                         if len(definitions[lang]) > 0 and "TRANSLATE" not in definitions[lang]:


### PR DESCRIPTION
This script will prompt the user for each word that is missing definition in a specified language. For example, if the language is Finnish, the script will iterate one-by-one each entry that lacks a non-autotranslated Finnish definition and ask the user to either confirm the autotranslation or provide a custom definition.